### PR TITLE
FW-4727, FW-4718, FW-4710 fix broken images

### DIFF
--- a/src/common/dataAdaptors/mediaAdaptors.js
+++ b/src/common/dataAdaptors/mediaAdaptors.js
@@ -1,6 +1,6 @@
 import { AUDIO, IMAGE, VIDEO } from 'common/constants'
 
-const mediaDataAdaptor = ({ type, data }) => {
+export const mediaAdaptor = ({ type, data }) => {
   if (!data) {
     return null
   }
@@ -46,5 +46,3 @@ const mediaDataAdaptor = ({ type, data }) => {
 
   return { ...data, message: 'NOT a media document' }
 }
-
-export default mediaDataAdaptor

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -22,7 +22,7 @@ export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
 
     case VIDEO:
     case IMAGE:
-      return mediaObject?.[size]?.path
+      return mediaObject?.[size]?.path || mediaObject?.original?.path
 
     default:
       return 'The media type supplied is not recognised by the getMediaPath helper'

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -19,8 +19,8 @@ export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
   switch (type) {
     case AUDIO:
       return mediaObject?.original?.path
-
     case VIDEO:
+      return mediaObject?.[size]?.path
     case IMAGE:
       return mediaObject?.[size]?.path || mediaObject?.original?.path
 

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -287,7 +287,7 @@ function DictionaryDetailPresentation({
                       </div>
                       <Disclosure>
                         <div className="flex justify-end">
-                          <div className="border-2 z-10 bg-white w-4 h-4 text-sm flex items-center justify-center p-1 rounded-full">
+                          <div className="border-2 z-10 bg-white w-6 h-6 text-sm flex items-center justify-center p-1 rounded-full">
                             <Disclosure.Button>
                               <span>i</span>
                             </Disclosure.Button>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -259,10 +259,7 @@ function DictionaryDetailPresentation({
                       <div className="inline-flex rounded-lg overflow-hidden relative ">
                         <div className="relative">
                           <div className="inline-flex rounded-lg overflow-auto">
-                            <ImageWithLightbox.Presentation
-                              maxWidth={1000}
-                              image={image}
-                            />
+                            <ImageWithLightbox.Presentation image={image} />
                           </div>
                         </div>
                       </div>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -192,10 +192,7 @@ function DictionaryDetailPresentationDrawer({
                       <div className="inline-flex rounded-lg overflow-hidden relative ">
                         <div className="relative">
                           <div className="inline-flex rounded-lg overflow-hidden cursor-pointer">
-                            <ImageWithLightbox.Presentation
-                              maxWidth={560}
-                              image={image}
-                            />
+                            <ImageWithLightbox.Presentation image={image} />
                           </div>
                         </div>
                       </div>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationKids.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationKids.js
@@ -13,7 +13,6 @@ function DictionaryDetailPresentationKids({ entry, backHandler }) {
           <div key={image.id} className="w-full inline-flex p-2">
             <ImageWithLightbox.Presentation
               imgStyling="object-contain rounded-lg w-full h-auto"
-              maxWidth={1000}
               image={image}
             />
           </div>

--- a/src/components/Gallery/GalleryPresentationWidget.js
+++ b/src/components/Gallery/GalleryPresentationWidget.js
@@ -24,11 +24,10 @@ function GalleryPresentationWidget({ data, sitename }) {
       <div className="text-center text-white text-xl">{data?.description}</div>
       <div className="mx-auto text-center">
         {images?.length > 0 &&
-          images?.map((image, index) => (
-            <div key={`${index}_${image?.uid}`} className="inline-flex m-2">
+          images?.map((image) => (
+            <div key={image?.id} className="inline-flex m-2">
               <ImageWithLightbox.Presentation
                 image={image}
-                maxWidth={120}
                 imgStyling="object-contain md:h-1/3-screen xl:h-2/5-screen w-full"
               />
             </div>

--- a/src/components/ImageWithLightbox/ImageWithLightboxPresentation.js
+++ b/src/components/ImageWithLightbox/ImageWithLightboxPresentation.js
@@ -68,7 +68,7 @@ ImageWithLightboxPresentation.propTypes = {
 }
 
 ImageWithLightboxPresentation.defaultProps = {
-  imgStyling: 'h-auto w-full',
+  imgStyling: 'h-auto w-full object-cover object-center',
 }
 
 export default ImageWithLightboxPresentation

--- a/src/components/ImageWithLightbox/ImageWithLightboxPresentation.js
+++ b/src/components/ImageWithLightbox/ImageWithLightboxPresentation.js
@@ -3,23 +3,29 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import Modal from 'components/Modal'
-import LazyImage from 'components/LazyImage'
 import { getMediaPath } from 'common/utils/mediaHelpers'
-import { IMAGE, ORIGINAL } from 'common/constants'
+import { IMAGE, ORIGINAL, SMALL } from 'common/constants'
 
-function ImageWithLightboxPresentation({ image, maxWidth, imgStyling }) {
+function ImageWithLightboxPresentation({ image, imgStyling }) {
   const [lightboxOpen, setLightboxOpen] = useState(false)
   return (
     <>
-      <LazyImage
-        imgStyling={imgStyling}
-        width={maxWidth}
-        onClick={() => setLightboxOpen(true)}
-        imageObject={image}
-        label="i"
-        forceLoad
+      <img
+        className={imgStyling}
+        src={getMediaPath({
+          mediaObject: image,
+          type: IMAGE,
+          size: SMALL,
+        })}
         alt={image?.title}
       />
+      <button
+        type="button"
+        onClick={() => setLightboxOpen(true)}
+        className="absolute border-2 z-10 bg-white w-6 h-6 text-sm flex items-center justify-center bottom-3 right-2 p-1 rounded-full"
+      >
+        i
+      </button>
       {/* Lightbox Modal */}
       <Modal.Presentation
         isOpen={lightboxOpen}
@@ -55,15 +61,13 @@ function ImageWithLightboxPresentation({ image, maxWidth, imgStyling }) {
   )
 }
 // PROPTYPES
-const { object, string, number } = PropTypes
+const { object, string } = PropTypes
 ImageWithLightboxPresentation.propTypes = {
-  maxWidth: number,
   imgStyling: string,
   image: object,
 }
 
 ImageWithLightboxPresentation.defaultProps = {
-  maxWidth: 1920,
   imgStyling: 'h-auto w-full',
 }
 

--- a/src/components/LazyImage/LazyImage.js
+++ b/src/components/LazyImage/LazyImage.js
@@ -6,16 +6,7 @@ import simpleSvgPlaceholder from 'common/utils/simpleSvgPlaceholder'
 import { IMAGE, MEDIUM, ORIGINAL, SMALL, THUMBNAIL } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 
-function LazyImage({
-  alt,
-  imageObject,
-  bgColor,
-  height,
-  width,
-  imgStyling,
-  onClick,
-  label,
-}) {
+function LazyImage({ alt, imageObject, bgColor, height, width, imgStyling }) {
   const [loaded, setLoaded] = useState(false)
   const imgRef = useRef()
 
@@ -67,11 +58,7 @@ function LazyImage({
   const aspectRatio = width / height
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`relative overflow-hidden ${imgStyling}`}
-    >
+    <div className={`relative overflow-hidden ${imgStyling}`}>
       <div style={{ paddingBottom: `${100 / aspectRatio}%` }} />
       <img src={placeholder} alt="Placeholder" aria-hidden="true" />
       <img
@@ -84,27 +71,16 @@ function LazyImage({
           loaded ? 'opacity-1' : 'opacity-0'
         }`}
       />
-      {label && (
-        <button
-          type="button"
-          onClick={onClick}
-          className="absolute border-2 z-10 bg-white w-4 h-4 text-sm flex items-center justify-center bottom-3 right-2 p-1 rounded-full"
-        >
-          {label}
-        </button>
-      )}
-    </button>
+    </div>
   )
 }
 
 // PROPTYPES
-const { func, number, object, string } = PropTypes
+const { number, object, string } = PropTypes
 LazyImage.propTypes = {
   alt: string,
-  label: string,
   imageObject: object,
   imgStyling: string,
-  onClick: func,
   height: number,
   width: number,
   bgColor: string,
@@ -113,7 +89,6 @@ LazyImage.propTypes = {
 LazyImage.defaultProps = {
   alt: '',
   imgStyling: 'w-full h-auto',
-  onClick: null,
 }
 
 export default LazyImage

--- a/src/components/MediaBrowser/MediaBrowserData.js
+++ b/src/components/MediaBrowser/MediaBrowserData.js
@@ -8,7 +8,7 @@ import { useSiteStore } from 'context/SiteContext'
 import api from 'services/api'
 import useIntersectionObserver from 'common/hooks/useIntersectionObserver'
 import { getFriendlyDocType } from 'common/utils/stringHelpers'
-import mediaDataAdaptor from 'common/utils/mediaDataAdaptor'
+import { mediaAdaptor } from 'common/dataAdaptors/mediaAdaptors'
 import { AUDIO, IMAGE, VIDEO } from 'common/constants'
 
 function MediaBrowserData({ docType }) {
@@ -78,7 +78,7 @@ function MediaBrowserData({ docType }) {
 
   useEffect(() => {
     if (!currentFile && data?.pages?.[0]?.results) {
-      const firstFile = mediaDataAdaptor({
+      const firstFile = mediaAdaptor({
         type: docType,
         data: data?.pages?.[0]?.results?.[0],
       })

--- a/src/components/MediaItemsLayout/MediaItemsLayoutAudio.js
+++ b/src/components/MediaItemsLayout/MediaItemsLayoutAudio.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
-import mediaDataAdaptor from 'common/utils/mediaDataAdaptor'
+import { mediaAdaptor } from 'common/dataAdaptors/mediaAdaptors'
 import AudioNative from 'components/AudioNative'
 import getIcon from 'common/utils/getIcon'
 import { AUDIO } from 'common/constants'
@@ -50,7 +50,7 @@ function MediaItemsLayoutAudio({
               {data?.pages?.map((page) => (
                 <React.Fragment key={page?.nextPage}>
                   {page.results.map((rawAudioDoc) => {
-                    const audioFile = mediaDataAdaptor({
+                    const audioFile = mediaAdaptor({
                       type: AUDIO,
                       data: rawAudioDoc,
                     })

--- a/src/components/MediaItemsLayout/MediaItemsLayoutVisual.js
+++ b/src/components/MediaItemsLayout/MediaItemsLayoutVisual.js
@@ -48,8 +48,8 @@ function MediaItemsLayoutVisual({
                         } group block w-full aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden`}
                       >
                         <img
-                          src={`${doc?.thumbnail}`}
-                          alt={`${doc?.title}`}
+                          src={doc?.thumbnail}
+                          alt={doc?.title}
                           className={`${
                             doc?.id === currentFile?.id
                               ? ''

--- a/src/components/MediaItemsLayout/MediaItemsLayoutVisual.js
+++ b/src/components/MediaItemsLayout/MediaItemsLayoutVisual.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import { IMAGE, VIDEO } from 'common/constants'
-import mediaDataAdaptor from 'common/utils/mediaDataAdaptor'
+import { mediaAdaptor } from 'common/dataAdaptors/mediaAdaptors'
 import getIcon from 'common/utils/getIcon'
 function MediaItemsLayoutVisual({
   data,
@@ -29,7 +29,7 @@ function MediaItemsLayoutVisual({
               // eslint-disable-next-line react/no-array-index-key
               <React.Fragment key={index}>
                 {page.results.map((rawDocument) => {
-                  const doc = mediaDataAdaptor({
+                  const doc = mediaAdaptor({
                     type: docType,
                     data: rawDocument,
                   })

--- a/src/components/MediaThumbnail/ImageThumbnail.js
+++ b/src/components/MediaThumbnail/ImageThumbnail.js
@@ -11,7 +11,7 @@ function ImageThumbnail(props) {
   const { id, size, alt, containerStyles, imageStyles, ...other } = props
 
   const { sitename } = useParams()
-  const [src, setSrc] = useState('')
+  const [src, setSrc] = useState()
 
   const mediaObject = useImageObject({ sitename, id })
 
@@ -29,7 +29,7 @@ function ImageThumbnail(props) {
   }, [src, setSrc, mediaObject, size])
 
   return (
-    <div className={containerStyles}>
+    <div id="MediaThumbnailImage" className={containerStyles}>
       <img
         src={src}
         alt={alt || mediaObject?.title}

--- a/src/components/Song/SongPresentation.js
+++ b/src/components/Song/SongPresentation.js
@@ -109,15 +109,11 @@ function SongPresentation({ entry }) {
 }
 
 const getMedia = ({ pictures, videos }) => (
-  <div>
+  <div className="space-y-4">
     {pictures.length > 0 && (
       <div className="space-y-4">
         {pictures?.map((picture) => (
-          <ImageWithLightbox.Presentation
-            maxWidth={1000}
-            image={picture}
-            key={picture.id}
-          />
+          <ImageWithLightbox.Presentation image={picture} key={picture.id} />
         ))}
       </div>
     )}

--- a/src/components/Story/StoryPresentation.js
+++ b/src/components/Story/StoryPresentation.js
@@ -17,10 +17,7 @@ function StoryPresentation({ entry }) {
       {entry?.coverVisual?.type === IMAGE && (
         <div className="grid grid-cols-2 md:gap-4 bg-white overflow-hidden shadow-lg">
           <div className="col-span-2 md:col-span-1 flex max-h-screen">
-            <ImageWithLightbox.Presentation
-              maxWidth={1000}
-              image={coverMedia}
-            />
+            <ImageWithLightbox.Presentation image={coverMedia} />
           </div>
           <div className="col-span-2 md:col-span-1 flex items-center ">
             <div className="px-4 py-2 md:p-6 space-y-4">


### PR DESCRIPTION
### Description of Changes

- Fix image styling on ImageWithLightbox
- Remove mouse click pointer from Hompage banner
- Increase size of info icon on ImageWithLightbox and videos on DictionaryDetail
- Add backup original path to getMediaPath when thumbnails are null
- Move mediaDataAdaptor into dataAdaptors folder and rename


### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
