### PR TITLE
Fw-4637, auto-refresh auth tokens

### DIFF
--- a/src/common/utils/authHelpers.js
+++ b/src/common/utils/authHelpers.js
@@ -21,7 +21,7 @@ function getUser() {
 export const getAuthHeaderIfTokenExists = () => {
   const user = getUser()
 
-  if (user != null) {
+  if (user != null && !user?.expired) {
     return {
       Authorization: `Bearer ${user.access_token}`,
     }

--- a/src/components/App/AppData.js
+++ b/src/components/App/AppData.js
@@ -16,18 +16,24 @@ function AppData() {
   } = useMySites()
 
   useEffect(() => {
-    if (
-      auth.isLoading === false &&
-      !auth.error &&
-      userRolesIsLoading === false &&
-      userRolesError === null
-    ) {
-      userDispatch({
-        type: 'SET',
-        data: { profile: auth?.user?.profile, memberships: mySitesData },
-      })
+    if (auth.isLoading === false && !auth.error) {
+      if (auth.user?.expired) {
+        auth.removeUser()
+      }
+      if (userRolesIsLoading === false && userRolesError === null) {
+        userDispatch({
+          type: 'SET',
+          data: { auth, memberships: mySitesData },
+        })
+      }
     }
-  }, [auth.isLoading, auth.error, userRolesIsLoading, userRolesError])
+  }, [
+    auth.isLoading,
+    auth.error,
+    auth.user?.expired,
+    userRolesIsLoading,
+    userRolesError,
+  ])
 
   return {
     appIsLoading: auth.isLoading,

--- a/src/context/UserContext.js
+++ b/src/context/UserContext.js
@@ -1,16 +1,18 @@
 import makeStore from 'context/makeStore'
 import { LANGUAGE_ADMIN, EDITOR, ASSISTANT } from 'common/constants/roles'
 
+const anonymousUser = {
+  isAnonymous: true,
+  userInitials: '',
+  displayName: 'Guest',
+  isTeam: false,
+  isLanguageAdmin: false,
+  isSuperAdmin: false,
+  roles: [],
+}
+
 export const userInitialState = {
-  user: {
-    firstName: 'Guest',
-    lastName: 'User',
-    username: 'Guest',
-    userInitials: 'GU',
-    displayName: 'Guest User',
-    groups: [],
-    roles: {},
-  },
+  user: anonymousUser,
   isLoading: true,
 }
 
@@ -60,17 +62,8 @@ function getRoles(memberships) {
 }
 
 const userDataAdaptor = (data) => {
-  if (!data?.profile) {
-    // anonymous user
-    return {
-      isAnonymous: true,
-      userInitials: '',
-      displayName: 'Guest',
-      isTeam: false,
-      isLanguageAdmin: false,
-      isSuperAdmin: false,
-      roles: [],
-    }
+  if (!data?.auth?.isAuthenticated) {
+    return anonymousUser
   }
 
   // authenticated user
@@ -82,7 +75,7 @@ const userDataAdaptor = (data) => {
     Object.values(roles).some((r) => r === ASSISTANT || r === EDITOR)
 
   // pull names from standard oidc claims in the user profile
-  const userProfile = data?.profile
+  const userProfile = data?.auth?.user?.profile
   const firstName = userProfile?.given_name || ''
   const lastName = userProfile?.family_name || ''
   const fullName = userProfile?.name || [firstName, lastName].join(' ') || ''

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ const oidcConfig = {
   client_id: GlobalConfiguration.AWS_CLIENT_ID,
   redirect_uri: GlobalConfiguration.OAUTH2_REDIRECT_URL,
   userStore: new WebStorageStateStore({ store: window.localStorage }),
+  automaticSilentRenew: true,
   onSigninCallback: () => {
     // redirect to original location
     const url = window.sessionStorage.getItem(ORIGINAL_DESTINATION)

--- a/src/services/api/categories.js
+++ b/src/services/api/categories.js
@@ -3,19 +3,19 @@ import { SITES, CATEGORIES } from 'common/constants'
 
 const categories = {
   get: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${CATEGORIES}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${CATEGORIES}/${id}`).json(),
   create: async ({ sitename, properties }) =>
-    apiBase
+    apiBase()
       .post(`${SITES}/${sitename}/${CATEGORIES}/`, { json: properties })
       .json(),
   update: async ({ sitename, id, properties }) =>
-    apiBase
+    apiBase()
       .put(`${SITES}/${sitename}/${CATEGORIES}/${id}`, { json: properties })
       .json(),
   delete: async ({ sitename, id }) =>
-    apiBase.delete(`${SITES}/${sitename}/${CATEGORIES}/${id}`).json(),
+    apiBase().delete(`${SITES}/${sitename}/${CATEGORIES}/${id}`).json(),
   getAll: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${CATEGORIES}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${CATEGORIES}/`).json(),
 }
 
 export default categories

--- a/src/services/api/characters.js
+++ b/src/services/api/characters.js
@@ -3,7 +3,7 @@ import { CHARACTERS, SITES } from 'common/constants'
 
 const characters = {
   get: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${CHARACTERS}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${CHARACTERS}/${id}`).json(),
   partialUpdate: async ({ sitename, id, properties }) => {
     const body = {
       related_audio: properties?.relatedAudio,
@@ -12,12 +12,12 @@ const characters = {
       note: properties?.note,
       related_dictionary_entries: properties?.relatedDictionaryEntries,
     }
-    return apiBase
+    return apiBase()
       .patch(`${SITES}/${sitename}/${CHARACTERS}/${id}`, { json: body })
       .json()
   },
   getAll: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${CHARACTERS}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${CHARACTERS}/`).json(),
 }
 
 export default characters

--- a/src/services/api/dictionary.js
+++ b/src/services/api/dictionary.js
@@ -3,17 +3,17 @@ import { DICTIONARY, SITES } from 'common/constants'
 
 const dictionary = {
   get: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${DICTIONARY}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${DICTIONARY}/${id}`).json(),
   create: async ({ sitename, properties }) =>
-    apiBase
+    apiBase()
       .post(`${SITES}/${sitename}/${DICTIONARY}/`, { json: properties })
       .json(),
   update: async ({ sitename, id, properties }) =>
-    apiBase
+    apiBase()
       .put(`${SITES}/${sitename}/${DICTIONARY}/${id}`, { json: properties })
       .json(),
   delete: async ({ sitename, id }) =>
-    apiBase.delete(`${SITES}/${sitename}/${DICTIONARY}/${id}`).json(),
+    apiBase().delete(`${SITES}/${sitename}/${DICTIONARY}/${id}`).json(),
 }
 
 export default dictionary

--- a/src/services/api/media.js
+++ b/src/services/api/media.js
@@ -11,7 +11,7 @@ import {
 const media = {
   get: async ({ sitename, docType, pageParam, perPage = 24 }) => {
     // Get list of media files of specified type for given site
-    const response = await apiBase
+    const response = await apiBase()
       .get(
         `${SITES}/${sitename}/${docType}/?page=${pageParam}&pageSize=${perPage}`,
       )
@@ -20,18 +20,21 @@ const media = {
     const nextPage = response?.next
     return { ...response, nextPage, lastPage }
   },
-  getAudio: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${AUDIO_PATH}/${id}`).json(),
+  getAudio: async ({ sitename, id, headers }) =>
+    apiBase()
+      .extend(headers)
+      .get(`${SITES}/${sitename}/${AUDIO_PATH}/${id}`)
+      .json(),
   getImage: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${IMAGE_PATH}/${id}`).json(),
+    apiBase()().get(`${SITES}/${sitename}/${IMAGE_PATH}/${id}`).json(),
   getVideo: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${VIDEO_PATH}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${VIDEO_PATH}/${id}`).json(),
   getMediaDocument: async ({ sitename, docId, docType }) =>
-    apiBase.get(`${SITES}/${sitename}/${docType}/${docId}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${docType}/${docId}`).json(),
   getUploadEndpoint: (sitename, docType) =>
     `${GlobalConfiguration.API_URL}${SITES}/${sitename}/${docType}`,
   uploadAudio: async ({ sitename, data }) =>
-    apiBase.post(`${SITES}/${sitename}/${AUDIO}`, { body: data }).json(),
+    apiBase().post(`${SITES}/${sitename}/${AUDIO}`, { body: data }).json(),
 }
 
 export default media

--- a/src/services/api/media.js
+++ b/src/services/api/media.js
@@ -26,7 +26,7 @@ const media = {
       .get(`${SITES}/${sitename}/${AUDIO_PATH}/${id}`)
       .json(),
   getImage: async ({ sitename, id }) =>
-    apiBase()().get(`${SITES}/${sitename}/${IMAGE_PATH}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${IMAGE_PATH}/${id}`).json(),
   getVideo: async ({ sitename, id }) =>
     apiBase().get(`${SITES}/${sitename}/${VIDEO_PATH}/${id}`).json(),
   getMediaDocument: async ({ sitename, docId, docType }) =>

--- a/src/services/api/pages.js
+++ b/src/services/api/pages.js
@@ -3,21 +3,23 @@ import { SITES, PAGES } from 'common/constants'
 
 const pages = {
   getPage: async ({ sitename, slug }) =>
-    apiBase.get(`${SITES}/${sitename}/${PAGES}/${slug}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${PAGES}/${slug}`).json(),
   create: async ({ sitename, properties }) =>
-    apiBase.post(`${SITES}/${sitename}/${PAGES}/`, { json: properties }).json(),
+    apiBase()
+      .post(`${SITES}/${sitename}/${PAGES}/`, { json: properties })
+      .json(),
   update: async ({ sitename, slug, properties }) =>
-    apiBase
+    apiBase()
       .put(`${SITES}/${sitename}/${PAGES}/${slug}`, { json: properties })
       .json(),
   partialUpdate: async ({ sitename, slug, properties }) =>
-    apiBase
+    apiBase()
       .patch(`${SITES}/${sitename}/${PAGES}/${slug}`, { json: properties })
       .json(),
   delete: async ({ sitename, slug }) =>
-    apiBase.delete(`${SITES}/${sitename}/${PAGES}/${slug}`).json(),
+    apiBase().delete(`${SITES}/${sitename}/${PAGES}/${slug}`).json(),
   getPages: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${PAGES}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${PAGES}/`).json(),
 }
 
 export default pages

--- a/src/services/api/partsOfSpeech.js
+++ b/src/services/api/partsOfSpeech.js
@@ -3,7 +3,7 @@ import { apiBase } from 'services/config'
 import { PARTS_OF_SPEECH } from 'common/constants'
 
 const partsOfSpeech = {
-  get: async () => apiBase.get(PARTS_OF_SPEECH).json(),
+  get: async () => apiBase().get(PARTS_OF_SPEECH).json(),
 }
 
 export default partsOfSpeech

--- a/src/services/api/people.js
+++ b/src/services/api/people.js
@@ -3,13 +3,13 @@ import { SITES, PEOPLE } from 'common/constants'
 
 const people = {
   get: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${PEOPLE}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${PEOPLE}/${id}`).json(),
   create: async ({ sitename, properties }) => {
     const body = {
       name: properties?.name,
       bio: properties?.bio,
     }
-    return apiBase
+    return apiBase()
       .post(`${SITES}/${sitename}/${PEOPLE}/`, { json: body })
       .json()
   },
@@ -18,14 +18,14 @@ const people = {
       name: properties?.name || null,
       bio: properties?.bio || null,
     }
-    return apiBase
+    return apiBase()
       .put(`${SITES}/${sitename}/${PEOPLE}/${id}`, { json: body })
       .json()
   },
   delete: async ({ sitename, id }) =>
-    apiBase.delete(`${SITES}/${sitename}/${PEOPLE}/${id}`).json(),
+    apiBase().delete(`${SITES}/${sitename}/${PEOPLE}/${id}`).json(),
   getAll: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${PEOPLE}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${PEOPLE}/`).json(),
 }
 
 export default people

--- a/src/services/api/search.js
+++ b/src/services/api/search.js
@@ -3,7 +3,7 @@ import { SEARCH, SITES } from 'common/constants'
 
 const search = {
   get: async ({ sitename, searchParams, page, perPage = 48 }) =>
-    apiBase
+    apiBase()
       .get(
         `${SITES}/${sitename}/${SEARCH}/?${searchParams}&page=${page}&pageSize=${perPage}`,
       )

--- a/src/services/api/site.js
+++ b/src/services/api/site.js
@@ -2,13 +2,13 @@ import { apiBase } from 'services/config'
 import { SITES, MY_SITES } from 'common/constants'
 
 const site = {
-  get: async ({ sitename }) => apiBase.get(`${SITES}/${sitename}/`).json(),
-  getSites: async () => apiBase.get(SITES).json(),
-  mySites: async () => apiBase.get(MY_SITES).json(),
+  get: async ({ sitename }) => apiBase().get(`${SITES}/${sitename}/`).json(),
+  getSites: async () => apiBase().get(SITES).json(),
+  mySites: async () => apiBase().get(MY_SITES).json(),
   update: async ({ sitename, properties }) =>
-    apiBase.put(`${SITES}/${sitename}/`, { json: properties }).json(),
+    apiBase().put(`${SITES}/${sitename}/`, { json: properties }).json(),
   partialUpdate: async ({ sitename, properties }) =>
-    apiBase.patch(`${SITES}/${sitename}/`, { json: properties }).json(),
+    apiBase().patch(`${SITES}/${sitename}/`, { json: properties }).json(),
 }
 
 export default site

--- a/src/services/api/song.js
+++ b/src/services/api/song.js
@@ -3,10 +3,10 @@ import { SITES, SONGS } from 'common/constants'
 
 const song = {
   getSongs: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${SONGS}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${SONGS}/`).json(),
 
   getSong: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${SONGS}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${SONGS}/${id}`).json(),
 }
 
 export default song

--- a/src/services/api/stories.js
+++ b/src/services/api/stories.js
@@ -3,9 +3,9 @@ import { SITES, STORIES } from 'common/constants'
 
 const stories = {
   get: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${STORIES}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${STORIES}/${id}`).json(),
   getAll: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${STORIES}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${STORIES}/`).json(),
 }
 
 export default stories

--- a/src/services/api/widgets.js
+++ b/src/services/api/widgets.js
@@ -3,22 +3,24 @@ import { SITES, WIDGETS, WORD_OF_THE_DAY } from 'common/constants'
 
 const widgets = {
   getWidget: async ({ sitename, id }) =>
-    apiBase.get(`${SITES}/${sitename}/${WIDGETS}/${id}`).json(),
+    apiBase().get(`${SITES}/${sitename}/${WIDGETS}/${id}`).json(),
   getWidgets: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${WIDGETS}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${WIDGETS}/`).json(),
   getWordOfTheDay: async ({ sitename }) =>
-    apiBase.get(`${SITES}/${sitename}/${WORD_OF_THE_DAY}/`).json(),
+    apiBase().get(`${SITES}/${sitename}/${WORD_OF_THE_DAY}/`).json(),
   getStats: async ({ sitename }) => ({
     message: `Stats API placeholder for ${sitename}`,
   }),
   create: async ({ sitename, formData }) =>
-    apiBase.post(`${SITES}/${sitename}/${WIDGETS}/`, { json: formData }).json(),
+    apiBase()
+      .post(`${SITES}/${sitename}/${WIDGETS}/`, { json: formData })
+      .json(),
   update: async ({ sitename, widgetId, formData }) =>
-    apiBase
+    apiBase()
       .put(`${SITES}/${sitename}/${WIDGETS}/${widgetId}/`, { json: formData })
       .json(),
   delete: async ({ sitename, widgetId }) =>
-    apiBase.delete(`${SITES}/${sitename}/${WIDGETS}/${widgetId}/`).json(),
+    apiBase().delete(`${SITES}/${sitename}/${WIDGETS}/${widgetId}/`).json(),
 }
 
 export default widgets

--- a/src/services/config.js
+++ b/src/services/config.js
@@ -9,11 +9,13 @@ export const apiV1 = ky.create({
   timeout: 60000,
 })
 
-export const apiBase = ky.create({
-  prefixUrl: GlobalConfiguration.API_URL,
-  timeout: 60000,
-  headers: getAuthHeaderIfTokenExists(),
-})
+export function apiBase() {
+  return ky.create({
+    prefixUrl: GlobalConfiguration.API_URL,
+    timeout: 60000,
+    headers: getAuthHeaderIfTokenExists(),
+  })
+}
 
 export const externalApi = ky.create({
   timeout: 60000,


### PR DESCRIPTION
### Description of Changes

- Token were already being refreshed, but the auth headers were never updated to use the new tokens. This changes apiBase to a function that always gets the latest token for the auth headers. (Performance is surprisingly fine!)
- Added handling for expired tokens-- instead of using them, we ignore them and treat the user as logged out.

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
