### PR TITLE
FW-4778, FW-4797, FW-4791 lazy loading only loads first page

### DIFF
--- a/src/common/dataHooks/useSearchLoader.js
+++ b/src/common/dataHooks/useSearchLoader.js
@@ -75,11 +75,11 @@ function useSearchLoader({ searchParams }) {
   // Fetch search results
   const response = useInfiniteQuery(
     [SEARCH, sitename, searchParamString],
-    ({ page = 1 }) =>
+    ({ pageParam = 1 }) =>
       api.search.get({
         sitename,
         searchParams: searchParamString,
-        page,
+        pageParam,
       }),
     {
       enabled: !!sitename,

--- a/src/components/CategoryCrud/CategoryCrudData.js
+++ b/src/components/CategoryCrud/CategoryCrudData.js
@@ -23,8 +23,8 @@ function CategoryCrudData() {
     useCategory({ id: categoryId })
 
   const getParentCategoryOptions = () => {
-    // If a category with no children allow assigning/changing a parent
-    if (categoryData?.children?.length < 1) {
+    // If a category with no children or a new category allow assigning/changing a parent
+    if (categoryData?.children?.length < 1 || !categoryId) {
       const categories = data?.results
         ? data?.results?.map((result) => {
             const category = { label: result?.title, value: result?.id }

--- a/src/components/DictionaryCrud/DictionaryCrudData.js
+++ b/src/components/DictionaryCrud/DictionaryCrudData.js
@@ -15,7 +15,7 @@ function DictionaryCrudData() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
 
-  const backHandler = () => navigate(-1)
+  const backHandler = () => navigate('..')
 
   const entryId = searchParams.get('id') || null
 

--- a/src/services/api/search.js
+++ b/src/services/api/search.js
@@ -2,10 +2,10 @@ import { apiBase } from 'services/config'
 import { SEARCH, SITES } from 'common/constants'
 
 const search = {
-  get: async ({ sitename, searchParams, page, perPage = 48 }) =>
+  get: async ({ sitename, searchParams, pageParam, perPage = 48 }) =>
     apiBase
       .get(
-        `${SITES}/${sitename}/${SEARCH}/?${searchParams}&page=${page}&pageSize=${perPage}`,
+        `${SITES}/${sitename}/${SEARCH}/?${searchParams}&page=${pageParam}&pageSize=${perPage}`,
       )
       .json(),
 }


### PR DESCRIPTION
### Description of Changes

- fixed bug where search infinite scroll was loading the same page over and over
- Allow assign parent category on category create
- Ensure dictionary crud cancel button always exits form - will now return to 'dashboard/create'

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
