### PR TITLE
fw-4826, all logos have same cropping

### DIFF
--- a/src/components/Dashboard/DashboardPresentationSiteSelect.js
+++ b/src/components/Dashboard/DashboardPresentationSiteSelect.js
@@ -17,10 +17,10 @@ function DashboardPresentationSiteSelect({ sites, site }) {
       <div>
         <Menu.Button className="group w-full bg-fv-charcoal text-white rounded-lg px-3.5 py-2 text-sm text-left font-medium hover:bg-fv-charcoal-light">
           <span className="flex w-full justify-between items-center">
-            <span className="flex min-w-0 items-center justify-between space-x-3">
+            <span className="flex min-w-0 items-center justify- between space-x-3">
               {site?.logoPathThumbnail ? (
                 <img
-                  className="h-12 w-12 bg-gray-300 rounded-full flex-shrink-0"
+                  className="h-12 w-12 bg-gray-300 rounded-full flex-shrink-0 object-cover object-center"
                   src={site?.logoPathThumbnail}
                   alt={`${site?.title} Logo`}
                 />

--- a/src/components/Dashboard/DashboardPresentationSiteSelect.js
+++ b/src/components/Dashboard/DashboardPresentationSiteSelect.js
@@ -17,7 +17,7 @@ function DashboardPresentationSiteSelect({ sites, site }) {
       <div>
         <Menu.Button className="group w-full bg-fv-charcoal text-white rounded-lg px-3.5 py-2 text-sm text-left font-medium hover:bg-fv-charcoal-light">
           <span className="flex w-full justify-between items-center">
-            <span className="flex min-w-0 items-center justify- between space-x-3">
+            <span className="flex min-w-0 items-center justify-between space-x-3">
               {site?.logoPathThumbnail ? (
                 <img
                   className="h-12 w-12 bg-gray-300 rounded-full flex-shrink-0 object-cover object-center"

--- a/src/components/DashboardLocator/DashboardLocatorPresentation.js
+++ b/src/components/DashboardLocator/DashboardLocatorPresentation.js
@@ -15,7 +15,7 @@ function DashboardLocatorPresentation({ site }) {
       <div className="flex-shrink-0">
         {site?.logoPathSmall ? (
           <img
-            className="flex max-w-xs bg-gray-300 rounded-full h-20 w-20 items-center justify-center"
+            className="flex max-w-xs bg-gray-300 rounded-full h-20 w-20 object-cover object-center"
             src={site?.logoPathSmall}
             alt={`${site?.title} Logo`}
           />

--- a/src/components/Home/HomePresentation.js
+++ b/src/components/Home/HomePresentation.js
@@ -16,6 +16,7 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
 
   const logoWidth = 'w-24 sm:w-32  md:w-44 lg:w-60'
   const logoHeight = 'h-24 sm:h-32 md:h-44 lg:h-60'
+  const logoPosition = 'items-center justify-center'
   const titleStyling = 'hidden md:block w-full text-center text-white text-2xl'
 
   function getContents(type) {
@@ -35,13 +36,15 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
               />
             </div>
             <div className="z-20 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-word to-word-dark">
-              <div className="flex flex-col md:flex-row items-center justify-center mx-auto p-3 md:p-5">
+              <div
+                className={`flex flex-col md:flex-row ${logoPosition} mx-auto p-3 md:p-5`}
+              >
                 <div
-                  className={`${logoWidth} md:-mt-24 lg:-mt-44 flex flex-col items-center justify-center mr-4`}
+                  className={`${logoWidth} md:-mt-24 lg:-mt-44 flex flex-col ${logoPosition} mr-4`}
                 >
                   <div className="flex flex-col w-full mb-2">
                     <LazyImage
-                      imgStyling={`${logoHeight} w-full rounded-full`}
+                      imgStyling={`${logoHeight} ${logoWidth} rounded-full`}
                       height={175}
                       width={175}
                       bgColor="none"
@@ -50,7 +53,7 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
                   </div>
                   <div className={titleStyling}>{site?.title}</div>
                 </div>
-                <div className="flex items-center justify-center w-full md:w-2/3">
+                <div className={`flex ${logoPosition} w-full md:w-2/3`}>
                   <div className="w-11/12 md:w-5/6 xl:w-3/4">
                     <SearchSiteForm.Container />
                   </div>
@@ -73,13 +76,15 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
               src={bgSrc}
             />
             <div className="w-full z-20 px-4 sm:px-6 lg:px-8">
-              <div className="flex flex-col md:flex-row items-center justify-center mx-auto p-3 md:p-5">
+              <div
+                className={`flex flex-col md:flex-row ${logoPosition} mx-auto p-3 md:p-5`}
+              >
                 <div
-                  className={`${logoWidth} flex flex-col items-center justify-center mr-4`}
+                  className={`${logoWidth} flex flex-col ${logoPosition} mr-4`}
                 >
                   <div className="flex w-full mb-2">
                     <LazyImage
-                      imgStyling={`${logoHeight} z-30 w-full rounded-full`}
+                      imgStyling={`${logoHeight} ${logoWidth} z-30 rounded-full`}
                       height={175}
                       width={175}
                       bgColor="none"
@@ -88,7 +93,7 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
                   </div>
                   <div className={titleStyling}>{site?.title}</div>
                 </div>
-                <div className="flex items-center justify-center w-full md:w-2/3">
+                <div className={`flex ${logoPosition} w-full md:w-2/3`}>
                   <div className="w-11/12 md:w-5/6 xl:w-3/4">
                     <SearchSiteForm.Container />
                   </div>
@@ -103,13 +108,13 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
             id="HomeBannerNoMedia"
             className="bg-gradient-to-b from-word to-word-dark"
           >
-            <div className="flex flex-col md:flex-row items-center justify-center mx-auto max-w-7xl p-3 md:p-5">
-              <div
-                className={`${logoWidth} flex flex-col items-center justify-center`}
-              >
+            <div
+              className={`flex flex-col md:flex-row ${logoPosition} mx-auto max-w-7xl p-3 md:p-5`}
+            >
+              <div className={`${logoWidth} flex flex-col ${logoPosition}`}>
                 <div className="flex mb-2">
                   <LazyImage
-                    imgStyling={`${logoHeight} w-full rounded-full`}
+                    imgStyling={`${logoHeight} ${logoWidth} rounded-full`}
                     height={175}
                     width={175}
                     bgColor="none"
@@ -118,7 +123,9 @@ function HomePresentation({ bannerMedia, bannerType, site }) {
                 </div>
                 <div className={titleStyling}>{site?.title}</div>
               </div>
-              <div className="flex items-center justify-center w-full md:w-2/3 xl:w-3/4 md:h-24">
+              <div
+                className={`flex ${logoPosition} w-full md:w-2/3 xl:w-3/4 md:h-24`}
+              >
                 <div className="w-11/12 md:w-5/6 xl:w-3/4">
                   <SearchSiteForm.Container />
                 </div>


### PR DESCRIPTION
### Description of Changes

* homepage banner is always a circle (height and width on same element)
* 2 dashboard logos and 3 homepage logo options all have same cropping style
* also i logged a ticket to make one reusable logo to rule them all (fw-4846)

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
