### PR TITLE
FW-4847 can t add widget to homepage

### DIFF
--- a/src/common/dataHooks/usePages.js
+++ b/src/common/dataHooks/usePages.js
@@ -119,7 +119,6 @@ export function usePageWidgetsUpdate({ pageSlug }) {
   }
   const mutation = useMutationWithNotification({
     mutationFn: updatePage,
-    redirectTo: `/${sitename}/dashboard/edit/page?slug=${pageSlug}`,
     queryKeyToInvalidate: [PAGES, sitename],
     actionWord: 'updated',
     type: 'widget list',

--- a/src/common/dataHooks/useSites.js
+++ b/src/common/dataHooks/useSites.js
@@ -78,7 +78,6 @@ export function useSiteUpdateWidgets() {
 
   const mutation = useMutationWithNotification({
     mutationFn: updateWidgets,
-    redirectTo: `/${sitename}/dashboard/edit/home`,
     queryKeyToInvalidate: [SITES, sitename],
     actionWord: 'updated',
     type: 'Home page widgets',

--- a/src/components/WidgetAreaEdit/WidgetAreaEditData.js
+++ b/src/components/WidgetAreaEdit/WidgetAreaEditData.js
@@ -28,7 +28,6 @@ function WidgetAreaEditData({ pageSlug, isHomepage }) {
   useEffect(() => {
     if (pageSlug && isInitialLoading === false && error === null) {
       const ids = data?.widgets?.map((w) => w.id) || []
-      console.log({ pageIds: ids })
       setWidgetIds(ids)
     }
   }, [isInitialLoading, error])

--- a/src/components/WidgetAreaEdit/WidgetAreaEditData.js
+++ b/src/components/WidgetAreaEdit/WidgetAreaEditData.js
@@ -5,10 +5,11 @@ import { useEffect, useState } from 'react'
 import { useSiteStore } from 'context/SiteContext'
 import { usePage, usePageWidgetsUpdate } from 'common/dataHooks/usePages'
 import { useSiteUpdateWidgets } from 'common/dataHooks/useSites'
+import { useWidgets } from 'common/dataHooks/useWidgets'
 
 function WidgetAreaEditData({ pageSlug, isHomepage }) {
   const [widgetIds, setWidgetIds] = useState([])
-  const [widgetValues, setWidgetValues] = useState()
+  const [widgetValues, setWidgetValues] = useState({})
   const { site } = useSiteStore()
   const [currentWidget, setCurrentWidget] = useState()
 
@@ -16,22 +17,35 @@ function WidgetAreaEditData({ pageSlug, isHomepage }) {
     pageSlug,
   })
 
-  // get list of widget IDs
+  // Fetch all widgets for this site
+  const {
+    widgets,
+    isInitialLoading: widgetsIsInitialLoading,
+    error: widgetsError,
+  } = useWidgets()
+
+  // If custom page set list of widget IDs in state
   useEffect(() => {
-    if (isInitialLoading === false && error === null) {
-      const ids = data?.widgets?.map((w) => w.id)
-      const values = widgetDataAdaptor(data?.widgets)
+    if (pageSlug && isInitialLoading === false && error === null) {
+      const ids = data?.widgets?.map((w) => w.id) || []
+      console.log({ pageIds: ids })
       setWidgetIds(ids)
-      setWidgetValues(values)
     }
   }, [isInitialLoading, error])
 
+  // Set widget objects in state
+  useEffect(() => {
+    if (widgetsIsInitialLoading === false && widgetsError === null) {
+      const values = widgetDataAdaptor(widgets)
+      setWidgetValues(values)
+    }
+  }, [widgetsIsInitialLoading, widgetsError])
+
+  // If homepage set list of widget IDs in state
   useEffect(() => {
     if (isHomepage) {
       const ids = site?.homepageWidgets?.map((w) => w.id)
-      const values = widgetDataAdaptor(site?.homepageWidgets)
       setWidgetIds(ids)
-      setWidgetValues(values)
     }
   }, [isHomepage, site])
 
@@ -66,7 +80,8 @@ function WidgetAreaEditData({ pageSlug, isHomepage }) {
   }
 
   const handleAddWidget = (id) => {
-    const filteredIds = [id, ...widgetIds]
+    // must supply array for sites with no widgets
+    const filteredIds = widgetIds?.length > 0 ? [id, ...widgetIds] : [id]
     saveWidgetOrder(filteredIds)
   }
 
@@ -76,7 +91,7 @@ function WidgetAreaEditData({ pageSlug, isHomepage }) {
     destinationTitle: isHomepage ? 'Home' : data?.title,
     handleRemoveWidget,
     handleAddWidget,
-    isLoading: isInitialLoading,
+    isLoading: isInitialLoading || widgetsIsInitialLoading,
     widgetData: widgetValues,
     widgetIds,
     setWidgetIds: updateWidgetOrder,


### PR DESCRIPTION
### Description of Changes

- Fixed bug where widgets couldn't be added to a homepage that had no widgets
- prevented refresh after reordering or adding a widget to a page
- ensured data for all widgets was available to display, not just data for the widgets already on the page.

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
