### PR TITLE
FW-4925 Pass character in searchParams not route

### DIFF
--- a/src/common/constants/paths.js
+++ b/src/common/constants/paths.js
@@ -1,3 +1,5 @@
+/* Paths for APIs */
+
 export const CATEGORIES = 'categories'
 export const CHARACTERS = 'characters'
 export const DICTIONARY = 'dictionary'

--- a/src/common/constants/searchParams.js
+++ b/src/common/constants/searchParams.js
@@ -28,3 +28,6 @@ export const TYPE_STORY = 'story'
 export const TYPE_WORD = 'word'
 export const TYPE_ENTRY = 'word,phrase,song,story'
 export const TYPE_DICTIONARY = 'word,phrase'
+
+/* Param Keys Frontend ONLY */
+export const CHAR = 'char'

--- a/src/components/Alphabet/AlphabetData.js
+++ b/src/components/Alphabet/AlphabetData.js
@@ -3,13 +3,14 @@ import { useParams, useSearchParams } from 'react-router-dom'
 
 // FPCC
 import { useCharacters } from 'common/dataHooks/useCharacters'
+import { CHAR } from 'common/constants'
 
 const AlphabetData = () => {
   const { sitename } = useParams()
   const [selectedData, setSelectedData] = useState()
   const [searchParams] = useSearchParams()
 
-  const character = searchParams.get('char') || null
+  const character = searchParams.get(CHAR) || null
 
   const { isInitialLoading, data } = useCharacters()
 

--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -6,7 +6,7 @@ import { Link, useParams } from 'react-router-dom'
 import getIcon from 'common/utils/getIcon'
 import AudioButton from 'components/AudioButton'
 import { Copy } from 'components/Actions'
-import { IMAGE, VIDEO, SMALL, ORIGINAL } from 'common/constants'
+import { CHAR, IMAGE, VIDEO, SMALL, ORIGINAL } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 function AlphabetPresentationSelected({
   kids,
@@ -128,7 +128,9 @@ function AlphabetPresentationSelected({
       )}
       <div className="flex justify-center">
         <Link
-          to={`/${sitename}/${kids ? 'kids/' : ''}alphabet/${title}`}
+          to={`/${sitename}/${
+            kids ? 'kids/' : ''
+          }alphabet/startsWith?${CHAR}=${title}`}
           className="inline-flex bg-primary hover:bg-primary-dark font-medium items-center justify-center px-5 py-2 mx-2 rounded-lg shadow-sm text-base text-center text-white"
         >
           <span>See all words starting with</span>

--- a/src/components/ByAlphabet/ByAlphabetData.js
+++ b/src/components/ByAlphabet/ByAlphabetData.js
@@ -7,6 +7,7 @@ import useSearchLoader from 'common/dataHooks/useSearchLoader'
 import { useCharacters } from 'common/dataHooks/useCharacters'
 import useSearchBoxNavigation from 'common/hooks/useSearchBoxNavigation'
 import {
+  CHAR,
   KIDS,
   STARTS_WITH_CHAR,
   TYPES,
@@ -15,10 +16,11 @@ import {
 
 function ByAlphabetData({ kids }) {
   const navigate = useNavigate()
-  const { sitename, character } = useParams()
+  const { sitename } = useParams()
   const [searchParams] = useSearchParams()
 
   const urlSearchType = searchParams.get(TYPES) || TYPE_DICTIONARY
+  const character = searchParams.get(CHAR)
   const { searchType, setSearchTypeInUrl, getSearchTypeLabel } =
     useSearchBoxNavigation({
       initialSearchType: urlSearchType,

--- a/src/components/ByAlphabet/ByAlphabetPresentation.js
+++ b/src/components/ByAlphabet/ByAlphabetPresentation.js
@@ -7,7 +7,7 @@ import DictionaryGrid from 'components/DictionaryGrid'
 import AudioButton from 'components/AudioButton'
 import SearchTypeSelector from 'components/SearchTypeSelector'
 import getIcon from 'common/utils/getIcon'
-import { TYPES, TYPE_DICTIONARY } from 'common/constants'
+import { CHAR, TYPES, TYPE_DICTIONARY } from 'common/constants'
 
 function ByAlphabetPresentation({
   actions,
@@ -34,7 +34,7 @@ function ByAlphabetPresentation({
         key={id}
         to={`/${sitename}/${
           kids ? 'kids/' : ''
-        }alphabet/${title}?${TYPES}=${searchType}`}
+        }alphabet/startsWith?${CHAR}=${title}&${TYPES}=${searchType}`}
       >
         {title}
       </Link>
@@ -144,7 +144,7 @@ function ByAlphabetPresentation({
 
         {kids ? (
           <div className="min-h-220 col-span-11 md:col-span-7 xl:col-span-8">
-            <div className="bg-gray-100 p-4">
+            <div className="bg-gray-100 p-4 min-h-screen">
               <DictionaryGrid.Presentation
                 actions={actions}
                 infiniteScroll={infiniteScroll}

--- a/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
+++ b/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import DashboardLanding from 'components/DashboardLanding'
 import DashboardTable from 'components/DashboardTable'
 import getIcon from 'common/utils/getIcon'
+import { CHAR } from 'common/constants'
 
 function DashboardAlphabetPresentation({
   headerContent,
@@ -89,7 +90,7 @@ function DashboardAlphabetPresentation({
               </td>
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
-                  to={`/${sitename}/alphabet/${character?.title}`}
+                  to={`/${sitename}/alphabet?${CHAR}=${character?.title}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-secondary hover:text-secondary-dark flex items-center"

--- a/src/components/Site/SiteFrame.js
+++ b/src/components/Site/SiteFrame.js
@@ -66,7 +66,7 @@ function SiteFrame({ siteLoading }) {
               element={<Dictionary.Container searchType={TYPE_PHRASE} />}
             />
             <Route
-              path="alphabet/:character"
+              path="alphabet/startsWith"
               element={<ByAlphabet.Container />}
             />
             <Route path="alphabet" element={<Alphabet.Container />} />

--- a/src/components/Site/SiteFrameKids.js
+++ b/src/components/Site/SiteFrameKids.js
@@ -61,7 +61,7 @@ function SiteFrameKids({ siteLoading }) {
               element={<Dictionary.Container searchType={TYPE_PHRASE} kids />}
             />
             <Route
-              path="alphabet/:character"
+              path="alphabet/startsWith"
               element={<ByAlphabet.Container kids />}
             />
             <Route path="alphabet" element={<Alphabet.Container kids />} />


### PR DESCRIPTION
### Description of Changes

Updated the `alphabet/:character` route to `alphabet/startsWith?char={character}` to fix case where character was `.` and was ignored by router

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
