### PR TITLE
FW-4821, FW-4862 duplicate page error and empty text error

### DIFF
--- a/src/common/constants/misc.js
+++ b/src/common/constants/misc.js
@@ -3,7 +3,7 @@ export const HEADER_ENRICHER = 'enrichers.document'
 export const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 export const FIRSTVOICESLINK = 'firstvoices.com'
-export const NOTIFICATION_TIME = 2000
+export const NOTIFICATION_TIME = 4000
 export const DISPLAYABLE_PROPS_MEDIA = [
   'filename',
   'title',

--- a/src/common/dataHooks/useMutationWithNotification.js
+++ b/src/common/dataHooks/useMutationWithNotification.js
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 // FPCC
 import { ERROR, SUCCESS } from 'common/constants'
 import { useNotification } from 'context/NotificationContext'
+import { convertJsonToReadableString } from 'common/utils/stringHelpers'
 
 export default function useMutationWithNotification({
   mutationFn,
@@ -31,12 +32,15 @@ export default function useMutationWithNotification({
         }, 1000)
       }
     },
-    onError: (error) => {
+    onError: async (error) => {
+      const response = await error?.response?.json()
+      const readableMessage = convertJsonToReadableString(response)
+
       setNotification({
         type: ERROR,
-        message: `ERROR: Your ${type} was NOT ${actionWord}. Please try again. If the error persists please contact FirstVoices Support. ${
-          error?.message ? `Server message: ${error?.message}` : ''
-        }`,
+        message: `ERROR: Your ${type} was NOT ${actionWord}. ${
+          readableMessage || ''
+        }Please try again. If the error persists please contact FirstVoices Support.`,
       })
     },
     onSettled: () => {

--- a/src/common/utils/stringHelpers.js
+++ b/src/common/utils/stringHelpers.js
@@ -315,6 +315,12 @@ export const safeJsonParse = (str) => {
   return false // default return case
 }
 
+// Converts JSON to a string and removes curly brackets, square brackets, and double quotes
+export const convertJsonToReadableString = (json) => {
+  const message = JSON.stringify(json)
+  return message?.replace(/[{}[\]"]+/g, ' ') || ''
+}
+
 export const makeTypeSingular = (plural) => {
   switch (plural) {
     case 'audio':

--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -38,7 +38,10 @@ export const definitions = {
   textArray: ({ charCount = 225 } = {}) =>
     yup.array().of(
       yup.object({
-        text: stringWithMax(charCount),
+        text: stringWithMax(charCount).min(
+          1,
+          'This field cannot be empty. Remove it if you do not want to inlcude it.',
+        ),
       }),
     ),
   url: ({ required = false } = {}) =>


### PR DESCRIPTION
### Description of Changes

- ensure error messages from server are included in notifications - ensures user feedback for case where an attempt is made to create a page with a duplicate slug
- Add validation message to textArray fields to prevent blank text value from being sent to server - e.g. Dictionary entry translation

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
