### PR TITLE
FW-2962, FW-4719 audio icon alignment

### DIFF
--- a/src/components/Audiobar/AudiobarData.js
+++ b/src/components/Audiobar/AudiobarData.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Howl, Howler } from 'howler'
 
 // FPCC
@@ -28,44 +28,47 @@ function AudiobarData() {
     return function cleanup() {
       setCurrentAudio()
     }
-  }, [currentAudio])
+  }, [currentAudio, generateSound, setCurrentAudio, sound])
 
-  const generateSound = (object) => {
-    const src = getMediaPath({ mediaObject: object, type: AUDIO })
-    const newHowl = new Howl({
-      src: [src],
-      rate,
-      html5: true, // Force to HTML5 so that the audio can stream in (best for large files).
-      onload() {
-        setDuration(formatTime(Math.round(newHowl.duration())))
-      },
-      onplay() {
-        setIsPlaying(true)
-        requestAnimationFrame(step)
-      },
-      onpause() {
-        setIsPlaying(false)
-      },
-      onend() {
-        setIsPlaying(false)
-      },
-    })
+  const generateSound = useCallback(
+    (object) => {
+      const src = getMediaPath({ mediaObject: object, type: AUDIO })
+      const newHowl = new Howl({
+        src: [src],
+        rate,
+        html5: true, // Force to HTML5 so that the audio can stream in (best for large files).
+        onload() {
+          setDuration(formatTime(Math.round(newHowl.duration())))
+        },
+        onplay() {
+          setIsPlaying(true)
+          requestAnimationFrame(step)
+        },
+        onpause() {
+          setIsPlaying(false)
+        },
+        onend() {
+          setIsPlaying(false)
+        },
+      })
 
-    const step = () => {
-      // Determine our current seek position.
-      const seek = newHowl?.seek() || 0
-      const currentTime = formatTime(Math.round(seek))
-      setCurTime(currentTime)
+      const step = () => {
+        // Determine our current seek position.
+        const seek = newHowl?.seek() || 0
+        const currentTime = formatTime(Math.round(seek))
+        setCurTime(currentTime)
 
-      // If the sound is still playing, continue stepping.
-      if (newHowl?.playing()) {
-        window.requestAnimationFrame(step)
+        // If the sound is still playing, continue stepping.
+        if (newHowl?.playing()) {
+          window.requestAnimationFrame(step)
+        }
       }
-    }
 
-    setSound({ id: object?.id, howl: newHowl })
-    newHowl.play()
-  }
+      setSound({ id: object?.id, howl: newHowl })
+      newHowl.play()
+    },
+    [rate],
+  )
 
   const formatTime = (secs) => {
     const minutes = Math.floor(secs / 60) || 0

--- a/src/components/Audiobar/AudiobarPresentation.js
+++ b/src/components/Audiobar/AudiobarPresentation.js
@@ -18,7 +18,7 @@ function AudiobarPresentation({
   return (
     <nav
       id="Audiobar"
-      className="transition-all transform fixed inset-x-0 bottom-0 z-10 h-24 bg-fv-charcoal shadow-xl print:hidden"
+      className="transition-all transform fixed inset-x-0 bottom-0 h-24 bg-fv-charcoal shadow-xl print:hidden"
     >
       {/* Infobar */}
       <section

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -4,13 +4,13 @@ import { Link } from 'react-router-dom'
 import { Disclosure } from '@headlessui/react'
 
 // FPCC
-import { makePlural } from 'common/utils/stringHelpers'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import getIcon from 'common/utils/getIcon'
 import AudioMinimal from 'components/AudioMinimal'
 import ActionsMenu from 'components/ActionsMenu'
 import ImageWithLightbox from 'components/ImageWithLightbox'
 import { ORIGINAL, VIDEO, PUBLIC } from 'common/constants'
+import RelatedEntriesTable from 'components/RelatedEntriesTable'
 
 function DictionaryDetailPresentation({
   actions,
@@ -18,7 +18,7 @@ function DictionaryDetailPresentation({
   entry,
   sitename,
 }) {
-  const lableStyling =
+  const labelStyling =
     'text-left font-medium text-lg uppercase text-fv-charcoal'
   const contentStyling = 'text-fv-charcoal sm:mt-0 sm:ml-6 sm:col-span-2'
   const noMedia = !(
@@ -134,7 +134,7 @@ function DictionaryDetailPresentation({
             {/* Categories */}
             {entry?.categories?.length > 0 && (
               <div className="py-2 md:p-4">
-                <h4 className={lableStyling}>Categories</h4>
+                <h4 className={labelStyling}>Categories</h4>
                 {entry?.categories?.map((category) => (
                   <Link
                     key={category.id}
@@ -148,67 +148,20 @@ function DictionaryDetailPresentation({
               </div>
             )}
             {/* Related Content */}
-            {entry?.relatedEntries?.length > 0 && (
-              <div className="py-2 md:p-4">
-                <table className="w-full">
-                  <thead>
-                    <tr>
-                      <th colSpan="2" className={`${lableStyling}pb-2`}>
-                        Related Content
-                      </th>
-                    </tr>
-                    <tr>
-                      <th className="hidden">Title</th>
-                      <th className="hidden">Definitions</th>
-                    </tr>
-                  </thead>
-                  <tbody className="py-2 px-10">
-                    {entry?.relatedEntries?.map((asset, index) => {
-                      const zebraStripe = index % 2 === 1 ? '' : 'bg-gray-100'
-                      return (
-                        <tr key={asset.id} className={zebraStripe}>
-                          <td className="p-2 flex items-center">
-                            <Link
-                              to={`/${sitename}/${makePlural(asset?.type)}/${
-                                asset.id
-                              }`}
-                            >
-                              {asset?.title}
-                            </Link>
-                            {asset?.relatedAudio?.map((audioObject) => (
-                              <AudioMinimal.Container
-                                key={audioObject?.id}
-                                icons={{
-                                  Play: getIcon(
-                                    'Audio',
-                                    'fill-current h-8 w-8 ml-2',
-                                  ),
-                                  Stop: getIcon(
-                                    'StopCircle',
-                                    'fill-current h-8 w-8 ml-2',
-                                  ),
-                                }}
-                                audioObject={audioObject}
-                              />
-                            ))}
-                          </td>
-                          <td className="p-2">
-                            <span>{asset?.translations?.[0]?.text}</span>
-                          </td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
-            )}
+            <div className="py-2 md:p-4">
+              <RelatedEntriesTable.Presentation
+                entries={entry?.relatedEntries || []}
+                sitename={sitename}
+                labelStyling={labelStyling}
+              />
+            </div>
           </section>
           {/* Other Information */}
           <section>
             {/* Acknowledgements */}
             {entry?.acknowledgements?.length > 0 && (
               <div className="py-2 md:p-4">
-                <h4 className={lableStyling}>Acknowledgement</h4>
+                <h4 className={labelStyling}>Acknowledgement</h4>
                 <ul className="list-none md:list-disc space-y-1">
                   {entry?.acknowledgements?.map((acknowledgement) => (
                     <li key={acknowledgement?.id} className={contentStyling}>
@@ -221,7 +174,7 @@ function DictionaryDetailPresentation({
             {/* Notes */}
             {entry?.notes?.length > 0 && (
               <div className="py-2 md:p-4">
-                <h4 className={lableStyling}>Notes</h4>
+                <h4 className={labelStyling}>Notes</h4>
                 <ul className="list-none md:list-disc space-y-1">
                   {entry?.notes?.map((note) => (
                     <li key={note?.id} className={contentStyling}>
@@ -234,7 +187,7 @@ function DictionaryDetailPresentation({
             {/* Pronunciations */}
             {entry?.pronunciations?.length > 0 && (
               <div className="py-2 md:p-4">
-                <h4 className={lableStyling}>Pronunciation</h4>
+                <h4 className={labelStyling}>Pronunciation</h4>
                 <ul className="list-none md:list-disc space-y-1">
                   {entry?.pronunciations?.map((pronunciation) => (
                     <li key={pronunciation?.id} className={contentStyling}>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -5,12 +5,12 @@ import { Disclosure } from '@headlessui/react'
 
 // FPCC
 import { ORIGINAL, VIDEO, PUBLIC } from 'common/constants'
-import { makePlural } from 'common/utils/urlHelpers'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import getIcon from 'common/utils/getIcon'
 import AudioMinimal from 'components/AudioMinimal'
 import ActionsMenu from 'components/ActionsMenu'
 import ImageWithLightbox from 'components/ImageWithLightbox'
+import RelatedEntriesTable from 'components/RelatedEntriesTable'
 
 function DictionaryDetailPresentationDrawer({
   actions,
@@ -18,7 +18,7 @@ function DictionaryDetailPresentationDrawer({
   entry,
   sitename,
 }) {
-  const lableStyling =
+  const labelStyling =
     'text-left font-medium text-lg uppercase text-fv-charcoal'
   const contentStyling = 'text-sm text-fv-charcoal sm:mt-0 sm:ml-6'
   const noMedia = !(
@@ -113,7 +113,7 @@ function DictionaryDetailPresentationDrawer({
           {/* Categories */}
           {entry?.categories?.length > 0 && (
             <div className="py-3">
-              <h4 className={lableStyling}>Categories</h4>
+              <h4 className={labelStyling}>Categories</h4>
               {entry?.categories?.map((category) => (
                 <Link
                   key={category?.id}
@@ -127,60 +127,14 @@ function DictionaryDetailPresentationDrawer({
             </div>
           )}
           {/* Related Content */}
-          {entry?.relatedEntries?.length > 0 && (
-            <div className="py-3">
-              <table className="w-full">
-                <thead>
-                  <tr>
-                    <th colSpan="2" className={`${lableStyling}pb-2`}>
-                      Related Content
-                    </th>
-                  </tr>
-                  <tr>
-                    <th className="hidden">Title</th>
-                    <th className="hidden">Definitions</th>
-                  </tr>
-                </thead>
-                <tbody className="py-2 px-10">
-                  {entry?.relatedEntries?.map((asset, index) => {
-                    const zebraStripe = index % 2 === 0 ? 'bg-gray-100' : ''
-                    return (
-                      <tr key={asset?.id} className={zebraStripe}>
-                        <td className="py-2 pl-5 flex items-center">
-                          <Link
-                            to={`/${sitename}/${makePlural(asset?.type)}/${
-                              asset?.id
-                            }`}
-                          >
-                            {asset ? asset?.title : null}
-                          </Link>
-                          {asset?.relatedAudio?.map((audioObject) => (
-                            <AudioMinimal.Container
-                              key={audioObject?.id}
-                              icons={{
-                                Play: getIcon(
-                                  'Audio',
-                                  'fill-current h-8 w-8 ml-2',
-                                ),
-                                Stop: getIcon(
-                                  'StopCircle',
-                                  'fill-current h-8 w-8 ml-2',
-                                ),
-                              }}
-                              audioObject={audioObject}
-                            />
-                          ))}
-                        </td>
-                        <td className="py-2 pr-5">
-                          <span>{asset?.translations?.[0]?.text}</span>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
+
+          <div className="py-3">
+            <RelatedEntriesTable.Presentation
+              entries={entry?.relatedEntries || []}
+              sitename={sitename}
+              labelStyling={labelStyling}
+            />
+          </div>
         </section>
         {/* Images and Video */}
         {noMedia ? null : (
@@ -255,7 +209,7 @@ function DictionaryDetailPresentationDrawer({
           {/* Acknowledgements */}
           {entry?.acknowledgements.length > 0 && (
             <div className="py-3">
-              <h4 className={lableStyling}>Acknowledgement</h4>
+              <h4 className={labelStyling}>Acknowledgement</h4>
               <ul className="list-disc">
                 {entry?.acknowledgements?.length > 0 &&
                   entry?.acknowledgements?.map((acknowledgement) => (
@@ -269,7 +223,7 @@ function DictionaryDetailPresentationDrawer({
           {/* Notes */}
           {entry?.notes?.length > 0 && (
             <div className="py-3">
-              <h4 className={lableStyling}>Notes</h4>
+              <h4 className={labelStyling}>Notes</h4>
               <ul className="list-disc">
                 {entry?.notes?.map((note) => (
                   <li key={note?.id} className={contentStyling}>
@@ -281,7 +235,7 @@ function DictionaryDetailPresentationDrawer({
           )}
           {entry?.pronunciations?.length > 0 && (
             <div className="py-3">
-              <h4 className={lableStyling}>Pronunciations</h4>
+              <h4 className={labelStyling}>Pronunciations</h4>
               <ul className="list-disc">
                 {entry?.pronunciations?.map((pronunciation) => (
                   <li key={pronunciation?.id} className={contentStyling}>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -88,7 +88,7 @@ function DictionaryDetailPresentationDrawer({
                     key={audioObject?.id}
                     icons={{
                       Play: getIcon(
-                        'Play',
+                        'Audio',
                         `fill-current h-6 w-6 md:w-4 md:h-4 ${
                           audioObject?.speakers?.length > 0 ? 'mr-2' : ''
                         }`,

--- a/src/components/DictionaryList/DictionaryListPresentation.js
+++ b/src/components/DictionaryList/DictionaryListPresentation.js
@@ -65,6 +65,9 @@ function DictionaryListPresentation({
     }
   }
 
+  const tableHeaderStyling =
+    'px-6 py-3 text-left text-xs font-medium text-fv-charcoal-light uppercase tracking-wider'
+
   return (
     <Loading.Container isLoading={isLoading}>
       {items?.pages !== undefined && items?.pages?.[0]?.results?.length > 0 ? (
@@ -95,30 +98,23 @@ function DictionaryListPresentation({
                         </div>
                       )}
                     </th>
-                    <th
-                      scope="col"
-                      className="px-6 py-3 text-left text-xs font-medium text-fv-charcoal-light uppercase tracking-wider"
-                    >
-                      TRANSLATION
+                    <th scope="col" className={tableHeaderStyling}>
+                      <span className="sr-only">Audio</span>
+                    </th>
+                    <th scope="col" className={tableHeaderStyling}>
+                      Translation
                     </th>
                     {showType && (
-                      <th
-                        scope="col"
-                        className="px-6 py-3 text-left text-xs font-medium text-fv-charcoal-light uppercase tracking-wider"
-                      >
+                      <th scope="col" className={tableHeaderStyling}>
                         Type
                       </th>
                     )}
                     {wholeDomain && (
-                      <th
-                        scope="col"
-                        className="px-6 py-3 text-left text-xs font-medium text-fv-charcoal-light uppercase tracking-wider"
-                      >
+                      <th scope="col" className={tableHeaderStyling}>
                         Language Site
                       </th>
                     )}
-
-                    <th scope="col" className="relative px-6 py-3">
+                    <th scope="col" className={tableHeaderStyling}>
                       <span className="sr-only">Actions</span>
                     </th>
                   </tr>
@@ -128,7 +124,7 @@ function DictionaryListPresentation({
                     <Fragment key={page.pageNumber}>
                       {page.results.map((entry) => (
                         <tr key={entry?.id}>
-                          <td className="px-6 py-4 flex justify-between">
+                          <td className="px-6 py-4">
                             <button
                               type="button"
                               className="text-left font-medium text-fv-charcoal lg:mr-2"
@@ -136,7 +132,9 @@ function DictionaryListPresentation({
                             >
                               {entry?.title}
                             </button>
-                            <div className="w-32">
+                          </td>
+                          <td className="py-4">
+                            <div className="inline-flex items-center">
                               <AudioButton
                                 audioArray={entry?.audio}
                                 iconStyling="fill-current text-fv-charcoal-light hover:text-fv-charcoal m-1 h-6 w-6"
@@ -177,7 +175,7 @@ function DictionaryListPresentation({
                               </Link>
                             </td>
                           )}
-                          <td className="text-right px-6">
+                          <td className="text-right px-6 py-4">
                             <ActionsMenu.Presentation
                               docId={entry?.id}
                               docTitle={entry?.title}

--- a/src/components/RelatedEntriesTable/RelatedEntriesTablePresentation.js
+++ b/src/components/RelatedEntriesTable/RelatedEntriesTablePresentation.js
@@ -1,0 +1,75 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+
+// FPCC
+import { makePlural } from 'common/utils/stringHelpers'
+import getIcon from 'common/utils/getIcon'
+import AudioMinimal from 'components/AudioMinimal'
+
+function RelatedEntriesTablePresentation({ entries, sitename, labelStyling }) {
+  return (
+    entries?.length > 0 && (
+      <table className="w-full">
+        <thead>
+          <tr>
+            <th colSpan="2" className={`${labelStyling} pb-2`}>
+              Related Content
+            </th>
+          </tr>
+          <tr>
+            <th className="hidden">Title</th>
+            <th className="hidden">Audio</th>
+            <th className="hidden">Translation</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries?.map((entry, index) => {
+            const zebraStripe = index % 2 === 0 ? 'bg-gray-100' : ''
+            return (
+              <tr key={entry?.id} className={zebraStripe}>
+                <td className="p-2">
+                  <Link
+                    to={`/${sitename}/${makePlural(entry?.type)}/${entry?.id}`}
+                  >
+                    {entry ? entry?.title : null}
+                  </Link>
+                </td>
+                <td className="p-2">
+                  <div className="inline-flex h-full items-center space-x-2">
+                    {entry?.relatedAudio?.map((audioObject) => (
+                      <AudioMinimal.Container
+                        key={audioObject?.id}
+                        icons={{
+                          Play: getIcon('Audio', 'fill-current h-8 w-8'),
+                          Stop: getIcon('StopCircle', 'fill-current h-8 w-8'),
+                        }}
+                        audioObject={audioObject}
+                      />
+                    ))}
+                  </div>
+                </td>
+                <td className="p-2">
+                  <span>{entry?.translations?.[0]?.text}</span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    )
+  )
+}
+// PROPTYPES
+const { array, string } = PropTypes
+RelatedEntriesTablePresentation.propTypes = {
+  entries: array,
+  sitename: string,
+  labelStyling: string,
+}
+
+RelatedEntriesTablePresentation.defaultProps = {
+  labelStyling: 'text-left font-medium text-lg uppercase text-fv-charcoal',
+}
+
+export default RelatedEntriesTablePresentation

--- a/src/components/RelatedEntriesTable/index.js
+++ b/src/components/RelatedEntriesTable/index.js
@@ -1,0 +1,5 @@
+import RelatedEntriesTablePresentation from 'components/RelatedEntriesTable/RelatedEntriesTablePresentation'
+
+export default {
+  Presentation: RelatedEntriesTablePresentation,
+}


### PR DESCRIPTION
### Description of Changes

- Fixed audio icon alignment for dictionary list view and related entries on dictionary detail - placed audio in separate column on the tables
- Matched audio icon in drawer and detail views
- Added a temporary fix for FW-2962 placed audiobar behind drawer so that the drawer isn't blocked by it


### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
