### PR TITLE
Fw 4765 kids sound icons align

### DIFF
--- a/src/components/DictionaryGridTile/DictionaryGridTilePresentationKids.js
+++ b/src/components/DictionaryGridTile/DictionaryGridTilePresentationKids.js
@@ -89,17 +89,19 @@ function DictionaryGridTilePresentationKids({ entry }) {
               </ol>
             )}
             {/* Entry Audio */}
-            {entry?.audio?.length > 0 &&
-              entry?.audio.map((audioObject) => (
-                <AudioMinimal.Container
-                  key={audioObject?.id}
-                  icons={{
-                    Play: getIcon('Audio', 'fill-current h-10 w-10'),
-                    Stop: getIcon('StopCircle', 'fill-current h-10 w-10'),
-                  }}
-                  audioObject={audioObject}
-                />
-              ))}
+            <div>
+              {entry?.audio?.length > 0 &&
+                entry?.audio.map((audioObject) => (
+                  <AudioMinimal.Container
+                    key={audioObject?.id}
+                    icons={{
+                      Play: getIcon('Audio', 'fill-current h-10 w-10'),
+                      Stop: getIcon('StopCircle', 'fill-current h-10 w-10'),
+                    }}
+                    audioObject={audioObject}
+                  />
+                ))}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Drawer/DrawerPresentation.js
+++ b/src/components/Drawer/DrawerPresentation.js
@@ -34,7 +34,7 @@ function DrawerPresentation({
               leaveTo="translate-x-full"
             >
               <div className={`w-screen ${maxWidth}`}>
-                <div className="h-full flex flex-col py-6 bg-white shadow-xl overflow-y-scroll">
+                <div className="h-full flex flex-col py-6 bg-white shadow-xl overflow-y-scroll touch-auto">
                   <div className="flex justify-end items-center mt-12 mr-2 space-x-2">
                     {fullScreenPath && (
                       <Link


### PR DESCRIPTION
### Description of Changes

formatting for audio button kids words
corrected scroll behaviour on touch screen - not sure how to test this.  Will need to check with Chris as I don't have an ipad

### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
