### PR TITLE
FW-4722-alphabet-btn-words-direct

### DIFF
--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -130,7 +130,7 @@ function AlphabetPresentationSelected({
         <Link
           to={`/${sitename}/${
             kids ? 'kids/' : ''
-          }alphabet/startsWith?${CHAR}=${title}`}
+          }alphabet/startsWith?${CHAR}=${title}&types=word`}
           className="inline-flex bg-primary hover:bg-primary-dark font-medium items-center justify-center px-5 py-2 mx-2 rounded-lg shadow-sm text-base text-center text-white"
         >
           <span>See all words starting with</span>


### PR DESCRIPTION
### Description of Changes

changed link path so that it points to only words rather than both words and phrases

### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
