### PR TITLE
FW-5023 Use new contact-us API

### DIFF
--- a/src/common/constants/paths.js
+++ b/src/common/constants/paths.js
@@ -2,6 +2,7 @@
 
 export const CATEGORIES = 'categories'
 export const CHARACTERS = 'characters'
+export const CONTACT_US = 'contact-us'
 export const DICTIONARY = 'dictionary'
 export const PAGES = 'pages'
 export const PARTS_OF_SPEECH = 'parts-of-speech'

--- a/src/common/dataAdaptors/contactUsAdaptor.js
+++ b/src/common/dataAdaptors/contactUsAdaptor.js
@@ -1,0 +1,7 @@
+export function contactUsAdaptor({ formData }) {
+  return {
+    name: formData?.name || '',
+    email: formData?.email || '',
+    message: formData?.message || '',
+  }
+}

--- a/src/common/dataHooks/useContactUs.js
+++ b/src/common/dataHooks/useContactUs.js
@@ -1,0 +1,48 @@
+import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+
+// FPCC
+import { CONTACT_US } from 'common/constants'
+import api from 'services/api'
+import { contactUsAdaptor } from 'common/dataAdaptors/contactUsAdaptor'
+import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
+
+export function useContactUsEmailList() {
+  const { sitename } = useParams()
+  const response = useQuery(
+    [CONTACT_US, sitename],
+    () => api.mail.get({ sitename }),
+    { enabled: !!sitename },
+  )
+
+  const emailList = response?.data?.[0]?.emailList
+  const emailListAsString = emailList
+    ?.map((v) => Object.values(v).join(''))
+    .join(' - ')
+
+  return { ...response, emailListAsString }
+}
+
+export function useContactUsSendEmail() {
+  const { sitename } = useParams()
+
+  const sendMail = async (formData) => {
+    const properties = contactUsAdaptor({ formData })
+    return api.mail.post({
+      sitename,
+      properties,
+    })
+  }
+
+  const mutation = useMutationWithNotification({
+    mutationFn: sendMail,
+    redirectTo: ``,
+    queryKeyToInvalidate: [CONTACT_US, sitename],
+    actionWord: 'sent',
+    type: 'email',
+  })
+
+  const onSubmit = (formData) => mutation.mutate(formData)
+
+  return { onSubmit }
+}

--- a/src/common/utils/widgetHelpers.js
+++ b/src/common/utils/widgetHelpers.js
@@ -21,7 +21,7 @@ export const getEditableWidgetsForUser = (isSuperAdmin) =>
   [
     isSuperAdmin && WIDGET_ALPHABET,
     isSuperAdmin && WIDGET_APPS,
-    // WIDGET_CONTACT,
+    WIDGET_CONTACT,
     // isSuperAdmin && WIDGET_GALLERY,
     //   WIDGET_IFRAME,
     isSuperAdmin && WIDGET_KEYBOARDS,

--- a/src/components/Widget/WidgetPresentation.js
+++ b/src/components/Widget/WidgetPresentation.js
@@ -21,7 +21,7 @@ import {
 
 import Alphabet from 'components/Alphabet'
 import WidgetApps from 'components/WidgetApps'
-// import WidgetContactUs from 'components/WidgetContactUs'
+import WidgetContactUs from 'components/WidgetContactUs'
 import Gallery from 'components/Gallery'
 import WidgetIframe from 'components/WidgetIframe'
 import WidgetKeyboards from 'components/WidgetKeyboards'
@@ -42,9 +42,8 @@ function WidgetPresentation({ data, type }) {
     case WIDGET_APPS:
       return <WidgetApps.Container widgetData={data} />
 
-    // hiding for FW-4713
-    // case WIDGET_CONTACT:
-    //   return <WidgetContactUs.Container widgetData={data} />
+    case WIDGET_CONTACT:
+      return <WidgetContactUs.Container widgetData={data} />
 
     case WIDGET_GALLERY:
       return <Gallery.Container widgetData={data} />

--- a/src/components/WidgetAreaEdit/WidgetAreaEditPresentationSettingsPane.js
+++ b/src/components/WidgetAreaEdit/WidgetAreaEditPresentationSettingsPane.js
@@ -194,38 +194,29 @@ function WidgetAreaEditPresentationSettingsPane({
               {getSettings()}
             </div>
             {currentWidget?.type === WIDGET_CONTACT && (
-              <div>
-                {emailListAsString?.length > 0 ? (
-                  <div className="mt-6">
-                    <dt className="mb-1 text-sm font-bold text-primary-light">
-                      Contact List
-                    </dt>
-                    <div className="col-span-12">
-                      <div className="mt-2 text-xs text-fv-charcoal-light italic">
-                        (Please contact support at hello@firstvoices.com to
-                        update this list)
-                      </div>
+              <div className="mt-6">
+                <dt className="mb-1 text-sm font-bold text-primary-light">
+                  Contact List
+                </dt>
+                <div className="col-span-12">
+                  <div className="mt-2 text-xs text-fv-charcoal-light italic">
+                    (Please contact support at hello@firstvoices.com to update
+                    this list)
+                  </div>
+                  {emailListAsString?.length > 0 ? (
+                    <div>
                       <div>
                         Contact us emails will be sent to the following
                         addresses:
                       </div>
                       <div>{emailListAsString}</div>
                     </div>
-                  </div>
-                ) : (
-                  <div className="mt-6">
-                    <dt className="mb-1 text-sm font-bold text-primary-light">
-                      Contact List
-                    </dt>
-                    <div className="mt-2 text-xs text-fv-charcoal-light italic">
-                      (Please contact support at hello@firstvoices.com to update
-                      this list)
-                    </div>
-                    <div className="col-span-12">
+                  ) : (
+                    <div>
                       Could not find any emails to send contact messages to.
                     </div>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/src/components/WidgetAreaEdit/WidgetAreaEditPresentationSettingsPane.js
+++ b/src/components/WidgetAreaEdit/WidgetAreaEditPresentationSettingsPane.js
@@ -17,12 +17,14 @@ import {
 } from 'common/utils/widgetHelpers'
 import getWidgetIcon from 'common/utils/getWidgetIcon'
 import {
+  WIDGET_CONTACT,
   WIDGET_WOTD,
   SETTING_WYSIWYG,
   SETTING_AUDIO,
   SETTING_IMAGE,
 } from 'common/constants'
 import MediaThumbnail from 'components/MediaThumbnail'
+import { useContactUsEmailList } from 'common/dataHooks/useContactUs'
 
 function WidgetAreaEditPresentationSettingsPane({
   currentWidget,
@@ -36,6 +38,8 @@ function WidgetAreaEditPresentationSettingsPane({
     handleRemoveWidget()
     setRemoveModalOpen(false)
   }
+
+  const { emailListAsString } = useContactUsEmailList()
 
   const getSettings = () => {
     if (currentWidget?.type === WIDGET_WOTD) {
@@ -189,6 +193,41 @@ function WidgetAreaEditPresentationSettingsPane({
               </div>
               {getSettings()}
             </div>
+            {currentWidget?.type === WIDGET_CONTACT && (
+              <div>
+                {emailListAsString?.length > 0 ? (
+                  <div className="mt-6">
+                    <dt className="mb-1 text-sm font-bold text-primary-light">
+                      Contact List
+                    </dt>
+                    <div className="col-span-12">
+                      <div className="mt-2 text-xs text-fv-charcoal-light italic">
+                        (Please contact support at hello@firstvoices.com to
+                        update this list)
+                      </div>
+                      <div>
+                        Contact us emails will be sent to the following
+                        addresses:
+                      </div>
+                      <div>{emailListAsString}</div>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-6">
+                    <dt className="mb-1 text-sm font-bold text-primary-light">
+                      Contact List
+                    </dt>
+                    <div className="mt-2 text-xs text-fv-charcoal-light italic">
+                      (Please contact support at hello@firstvoices.com to update
+                      this list)
+                    </div>
+                    <div className="col-span-12">
+                      Could not find any emails to send contact messages to.
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/src/components/WidgetContactUs/WidgetContactUsContainer.js
+++ b/src/components/WidgetContactUs/WidgetContactUsContainer.js
@@ -4,12 +4,15 @@ import PropTypes from 'prop-types'
 // FPCC
 import WidgetContactUsPresentation from 'components/WidgetContactUs/WidgetContactUsPresentation'
 import WidgetContactUsData from 'components/WidgetContactUs/WidgetContactUsData'
+import { useUserStore } from 'context/UserContext'
 
 function WidgetContactUsContainer({ widgetData }) {
   const { title, text, textWithFormatting } = widgetData?.settings
   const { siteTitle, links, submitHandler } = WidgetContactUsData({
     widgetData,
   })
+
+  const { user } = useUserStore()
 
   return (
     <WidgetContactUsPresentation
@@ -19,6 +22,7 @@ function WidgetContactUsContainer({ widgetData }) {
       textWithFormatting={textWithFormatting}
       links={links}
       submitHandler={submitHandler}
+      user={user}
     />
   )
 }

--- a/src/components/WidgetContactUs/WidgetContactUsData.js
+++ b/src/components/WidgetContactUs/WidgetContactUsData.js
@@ -1,12 +1,10 @@
 // FPCC
 import { useSiteStore } from 'context/SiteContext'
-import api from 'services/api'
-import { useNotification } from 'context/NotificationContext'
+import { useContactUsSendEmail } from 'common/dataHooks/useContactUs'
 
 function ContactUsData({ widgetData }) {
   const { site } = useSiteStore()
-  const { title, id } = site
-  const { setNotification } = useNotification()
+  const { title } = site
 
   let links = []
   const linkString = widgetData?.settings?.urls || ''
@@ -14,53 +12,10 @@ function ContactUsData({ widgetData }) {
     links = linkString.split(',')
   }
 
+  const { onSubmit: sendMail } = useContactUsSendEmail()
+
   const submitHandler = async (formData) => {
-    if (formData) {
-      sendMessage(formData)
-    }
-  }
-
-  const sendMessage = async (formData) => {
-    try {
-      const response = await api.mail.post({
-        siteId: id,
-        name: formData.name,
-        from: formData.email,
-        message: formData.message,
-      })
-
-      if (response?.status === 202) {
-        setNotification({
-          type: 'SUCCESS',
-          message: 'Thank you for emailing the Language Team.',
-        })
-      }
-    } catch (error) {
-      if (error?.name === 'HTTPError') {
-        switch (error?.response?.status) {
-          case 400:
-            setNotification({
-              type: 'ERROR',
-              message: `We've encountered the following error: ${error?.message}.`,
-            })
-            break
-          case 429:
-            setNotification({
-              type: 'ERROR',
-              message:
-                'We have detected potential SPAM issue. Please try again in a few minutes or contact our Help Desk.',
-            })
-            break
-          default:
-            setNotification({
-              type: 'ERROR',
-              message:
-                'We have encountered an unexpected error. Please report this to our Help Desk.',
-            })
-            break
-        }
-      }
-    }
+    sendMail(formData)
   }
 
   return {

--- a/src/components/WidgetContactUs/WidgetContactUsPresentation.js
+++ b/src/components/WidgetContactUs/WidgetContactUsPresentation.js
@@ -15,6 +15,7 @@ function ContactUsPresentation({
   textWithFormatting,
   links,
   submitHandler,
+  user,
 }) {
   const validator = yup.object().shape({
     name: yup.string().min(3).required('A name is required').trim(),
@@ -26,7 +27,6 @@ function ContactUsPresentation({
       .required('A Message is required')
       .trim(),
   })
-
   const defaultValues = {
     name: '',
     email: '',
@@ -89,111 +89,119 @@ function ContactUsPresentation({
           title={title || `Contact ${siteTitle} Team`}
         />
       </div>
-      <div className="text-primary md:text-xl text-center mb-2 md:mb-6 px-2 lg:px-8">
-        {subtitle ||
-          'Please contact us if you have any suggestions or feedback regarding our language content.'}
-      </div>
-      <div className="max-w-7xl mx-auto px-3 md:px-6 lg:px-8">
-        <div className="grid grid-cols-6">
-          <form className="col-span-6 md:col-span-3">
-            <div className="">
-              <div className="grid grid-cols-7">
-                <label
-                  className="col-span-2 tracking-wide text-primary text-xl font-bold mb-2"
-                  htmlFor="name"
-                >
-                  NAME:
-                </label>
-                <input
-                  className="col-span-5 bg-white border border-gray-500 rounded-lg py-3 px-4 leading-tight focus:outline-none focus:bg-white"
-                  id="name"
-                  name="name"
-                  type="text"
-                  {...register('name')}
-                />
-              </div>
-              {errors?.name && (
-                <div className="text-red-500 text-right">
-                  {errors?.name?.message}
-                </div>
-              )}
+      {user.isAnonymous ? (
+        <div className="text-primary md:text-xl text-center mb-2 md:mb-6 px-2 lg:px-8">
+          Please sign in to use the contact us form.
+        </div>
+      ) : (
+        <div>
+          <div className="text-primary md:text-xl text-center mb-2 md:mb-6 px-2 lg:px-8">
+            {subtitle ||
+              'Please contact us if you have any suggestions or feedback regarding our language content.'}
+          </div>
+          <div className="max-w-7xl mx-auto px-3 md:px-6 lg:px-8">
+            <div className="grid grid-cols-6">
+              <form className="col-span-6 md:col-span-3">
+                <div className="">
+                  <div className="grid grid-cols-7">
+                    <label
+                      className="col-span-2 tracking-wide text-primary text-xl font-bold mb-2"
+                      htmlFor="name"
+                    >
+                      NAME:
+                    </label>
+                    <input
+                      className="col-span-5 bg-white border border-gray-500 rounded-lg py-3 px-4 leading-tight focus:outline-none focus:bg-white"
+                      id="name"
+                      name="name"
+                      type="text"
+                      {...register('name')}
+                    />
+                  </div>
+                  {errors?.name && (
+                    <div className="text-red-500 text-right">
+                      {errors?.name?.message}
+                    </div>
+                  )}
 
-              <div className="mt-2 grid grid-cols-7">
-                <label
-                  className="col-span-2 tracking-wide text-primary text-xl font-bold mb-2"
-                  htmlFor="email"
-                >
-                  EMAIL:
-                </label>
-                <input
-                  className="col-span-5 inline bg-white border border-gray-500 rounded-lg py-3 px-4 leading-tight focus:outline-none focus:bg-white"
-                  id="email"
-                  name="email"
-                  type="email"
-                  {...register('email')}
-                />
-              </div>
-              {errors?.email && (
-                <div className="text-red-500 text-right">
-                  {errors?.email?.message}
-                </div>
-              )}
+                  <div className="mt-2 grid grid-cols-7">
+                    <label
+                      className="col-span-2 tracking-wide text-primary text-xl font-bold mb-2"
+                      htmlFor="email"
+                    >
+                      EMAIL:
+                    </label>
+                    <input
+                      className="col-span-5 inline bg-white border border-gray-500 rounded-lg py-3 px-4 leading-tight focus:outline-none focus:bg-white"
+                      id="email"
+                      name="email"
+                      type="email"
+                      {...register('email')}
+                    />
+                  </div>
+                  {errors?.email && (
+                    <div className="text-red-500 text-right">
+                      {errors?.email?.message}
+                    </div>
+                  )}
 
-              <div className="mt-2 grid grid-cols-7">
-                <label
-                  className="block tracking-wide text-primary text-xl font-bold mb-2"
-                  htmlFor="message"
-                >
-                  MESSAGE:
-                </label>
-                <textarea
-                  className="h-32 lg:h-48 no-resize appearance-none block w-full bg-white border border-gray-500 rounded-lg py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 resize-none col-span-7"
-                  id="message"
-                  name="message"
-                  defaultValue=""
-                  {...register('message')}
-                />
-              </div>
-              {errors?.message && (
-                <div className="text-red-500 text-right">
-                  {errors?.message?.message}
-                </div>
-              )}
+                  <div className="mt-2 grid grid-cols-7">
+                    <label
+                      className="block tracking-wide text-primary text-xl font-bold mb-2"
+                      htmlFor="message"
+                    >
+                      MESSAGE:
+                    </label>
+                    <textarea
+                      className="h-32 lg:h-48 no-resize appearance-none block w-full bg-white border border-gray-500 rounded-lg py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500 resize-none col-span-7"
+                      id="message"
+                      name="message"
+                      defaultValue=""
+                      {...register('message')}
+                    />
+                  </div>
+                  {errors?.message && (
+                    <div className="text-red-500 text-right">
+                      {errors?.message?.message}
+                    </div>
+                  )}
 
-              <div className="col-span-7 justify-start flex">
-                <button
-                  type="submit"
-                  className="text-center shadow bg-primary hover:bg-primary-dark focus:shadow-outline text-white font-bold py-2 px-4 rounded-lg"
-                  onClick={handleSubmit(submitHandler)}
-                >
-                  Submit
-                </button>
+                  <div className="col-span-7 justify-start flex">
+                    <button
+                      type="submit"
+                      className="text-center shadow bg-primary hover:bg-primary-dark focus:shadow-outline text-white font-bold py-2 px-4 rounded-lg"
+                      onClick={handleSubmit(submitHandler)}
+                    >
+                      Submit
+                    </button>
+                  </div>
+                </div>
+              </form>
+              <div className="col-span-6 sm:col-start-5 sm:col-span-2 mt-8 sm:mt-0">
+                {textWithFormatting && (
+                  <>
+                    <h3 className="block tracking-wide text-primary text-xl font-bold mb-2">
+                      ADDRESS
+                    </h3>
+                    <div className="block mb-6">
+                      <WysiwygBlock jsonString={textWithFormatting} />
+                    </div>
+                  </>
+                )}
+                <h3 className="block tracking-wide text-primary text-xl font-bold mb-2">
+                  FOLLOW US
+                </h3>
+                <ul className="block">{socialIcons}</ul>
               </div>
             </div>
-          </form>
-          <div className="col-span-6 sm:col-start-5 sm:col-span-2 mt-8 sm:mt-0">
-            {textWithFormatting && (
-              <>
-                <h3 className="block tracking-wide text-primary text-xl font-bold mb-2">
-                  ADDRESS
-                </h3>
-                <div className="block mb-6">
-                  <WysiwygBlock jsonString={textWithFormatting} />
-                </div>
-              </>
-            )}
-            <h3 className="block tracking-wide text-primary text-xl font-bold mb-2">
-              FOLLOW US
-            </h3>
-            <ul className="block">{socialIcons}</ul>
           </div>
         </div>
-      </div>
+      )}
     </section>
   )
 }
 // PROPTYPES
-const { array, func, string } = PropTypes
+const { array, func, string, object } = PropTypes
 ContactUsPresentation.propTypes = {
   title: string,
   subtitle: string,
@@ -201,6 +209,7 @@ ContactUsPresentation.propTypes = {
   textWithFormatting: string,
   links: array,
   submitHandler: func,
+  user: object,
 }
 
 export default ContactUsPresentation

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -9,6 +9,7 @@ import { WIDGET_CONTACT, FORMAT_DEFAULT, PUBLIC } from 'common/constants'
 import { definitions } from 'common/utils/validationHelpers'
 import WidgetFormBase from 'components/WidgetCrud/WidgetFormBase'
 import { EditorState } from 'draft-js'
+import { useContactUsEmailList } from 'common/dataHooks/useContactUs'
 
 function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
   const validator = yup.object().shape({
@@ -39,6 +40,8 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
       validator,
       dataToEdit,
     })
+
+  const { emailListAsString } = useContactUsEmailList()
 
   return (
     <div data-testid="WidgetFormContact">
@@ -88,6 +91,34 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
               errors={errors}
             />
           </div>
+          {emailListAsString?.length > 0 ? (
+            <div className="col-span-12 mt-2 text-sm text-fv-charcoal-light">
+              <div className="block text-sm font-medium text-fv-charcoal">
+                Contact List
+              </div>
+              <div className="mt-2 text-xs text-fv-charcoal-light italic">
+                (Please contact support at hello@firstvoices.com to update this
+                list)
+              </div>
+              <div className="mt-2 text-sm text-fv-charcoal-light">
+                Contact us emails will be sent to the following addresses:
+              </div>
+              <div>{emailListAsString}</div>
+            </div>
+          ) : (
+            <div className="col-span-12">
+              <div className="block text-sm font-medium text-fv-charcoal">
+                Contact List
+              </div>
+              <div className="mt-2 text-xs text-fv-charcoal-light italic">
+                (Please contact support at hello@firstvoices.com to update this
+                list)
+              </div>
+              <div className="mt-2 text-sm text-fv-charcoal-light">
+                Could not find any emails to send contact messages to.
+              </div>
+            </div>
+          )}
         </>
       </WidgetFormBase>
     </div>

--- a/src/services/api/mail.js
+++ b/src/services/api/mail.js
@@ -1,15 +1,13 @@
-import { apiV1 } from 'services/config'
+import { apiBase } from 'services/config'
+import { SITES, CONTACT_US } from 'common/constants'
 
 const mail = {
-  post: async ({ siteId, from, message, name }) => {
-    const params = {
-      emailAddress: from,
-      messageBody: message,
-      idOfDialect: siteId,
-      name,
-    }
-    return apiV1.post('contact_us', { json: params })
-  },
+  post: async ({ sitename, properties }) =>
+    apiBase()
+      .post(`${SITES}/${sitename}/${CONTACT_US}/`, { json: properties })
+      .json(),
+  get: async ({ sitename }) =>
+    apiBase().get(`${SITES}/${sitename}/${CONTACT_US}/`).json(),
 }
 
 export default mail


### PR DESCRIPTION
### Description of Changes
This PR re-enables the contact-us widget and form using the new contact-us API. 

If the user is not logged in the form fields will be hidden and text prompting the user to log in will be shown.

The edit/create widget pages will now show the list of addresses that the contact form will send emails to, as well as some text informing the user to contact support if they would like to update the list.

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [x] Pull the branch and test locally

### Additional Notes
N/A
