### PR TITLE
FW-5100 Fix story preview text translation swap

### DIFF
--- a/src/components/StoryCrud/StoryCrudPreview.js
+++ b/src/components/StoryCrud/StoryCrudPreview.js
@@ -165,8 +165,8 @@ function StoryCrudPreview({ storyData }) {
                   <WysiwygBlock
                     jsonString={
                       translate
-                        ? currentPage?.text
-                        : currentPage?.textTranslation
+                        ? currentPage?.textTranslation
+                        : currentPage?.text
                     }
                   />
                   {translateButton()}


### PR DESCRIPTION
### Description of Changes

This PR fixes the story preview text translation being shown by default and the regular text is shown when the translation button is pressed.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
