### PR TITLE
FW-5074-reverse-visibility-selector

### DIFF
--- a/src/common/dataAdaptors/siteAdaptors.js
+++ b/src/common/dataAdaptors/siteAdaptors.js
@@ -79,9 +79,9 @@ const constructVisibilityOptions = (siteVisibility) => {
     }))
   switch (siteVisibility) {
     case PUBLIC:
-      return formattedVisibilityOptions([TEAM, MEMBERS, PUBLIC])
+      return formattedVisibilityOptions([PUBLIC, MEMBERS, TEAM])
     case MEMBERS:
-      return formattedVisibilityOptions([TEAM, MEMBERS])
+      return formattedVisibilityOptions([MEMBERS, TEAM])
     case TEAM:
     default:
       return formattedVisibilityOptions([TEAM])


### PR DESCRIPTION
### Description of Changes

reversed the order of the visibility selectors to drill down from public>members>team

### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
