### PR TITLE
FW-4810 Update assistant page redirects after item creation

### DIFF
--- a/src/common/dataHooks/useDictionaryEntry.js
+++ b/src/common/dataHooks/useDictionaryEntry.js
@@ -5,6 +5,8 @@ import { useParams } from 'react-router-dom'
 import { DICTIONARY, TYPE_DICTIONARY } from 'common/constants'
 import api from 'services/api'
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
+import { useUserStore } from 'context/UserContext'
+import { ASSISTANT } from 'common/constants/roles'
 
 import {
   entryForEditing,
@@ -40,9 +42,16 @@ export function useDictionaryEntryCreate() {
     })
   }
 
+  const { user } = useUserStore()
+  const userRoles = user?.roles || {}
+  const userSiteRole = userRoles?.[sitename] || ''
+  const isAssistant = userSiteRole === ASSISTANT
+
   const mutation = useMutationWithNotification({
     mutationFn: createDictionaryEntry,
-    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_DICTIONARY}`,
+    redirectTo: isAssistant // Redirect to the create page for assistants to be removed when assistants can access the edit pages (FW-4828)
+      ? `/${sitename}/dashboard/create/`
+      : `/${sitename}/dashboard/edit/entries?types=${TYPE_DICTIONARY}`,
     queryKeyToInvalidate: [DICTIONARY, sitename],
     actionWord: 'created',
     type: 'dictionary entry',

--- a/src/common/dataHooks/useSongs.js
+++ b/src/common/dataHooks/useSongs.js
@@ -10,6 +10,8 @@ import {
   songForApi,
 } from 'common/dataAdaptors/songAdaptors'
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
+import { useUserStore } from 'context/UserContext'
+import { ASSISTANT } from 'common/constants/roles'
 
 export function useSongs() {
   const { sitename } = useParams()
@@ -68,9 +70,16 @@ export function useSongCreate() {
     })
   }
 
+  const { user } = useUserStore()
+  const userRoles = user?.roles || {}
+  const userSiteRole = userRoles?.[sitename] || ''
+  const isAssistant = userSiteRole === ASSISTANT
+
   const mutation = useMutationWithNotification({
     mutationFn: createSong,
-    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
+    redirectTo: isAssistant // Redirect to the create page for assistants to be removed when assistants can access the edit pages (FW-4828)
+      ? `/${sitename}/dashboard/create`
+      : `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
     queryKeyToInvalidate: [SONGS, sitename],
     actionWord: 'created',
     type: 'song',

--- a/src/components/Form/NextPrevious.js
+++ b/src/components/Form/NextPrevious.js
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom'
 // FPCC
 import getIcon from 'common/utils/getIcon'
 import useSearchParamsState from 'common/hooks/useSearchParamsState'
+import { useUserStore } from 'context/UserContext'
+import { ASSISTANT } from '../../common/constants/roles'
 
 function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
   const [activeStep, setActiveStep] = useSearchParamsState({
@@ -19,6 +21,11 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
       onClickCallback(String(stepToGoTo))
     } else return setActiveStep(String(stepToGoTo))
   }
+
+  const { user } = useUserStore()
+  const userRoles = user?.roles || {}
+  const userSiteRole = userRoles?.[sitename] || ''
+  const isAssistant = userSiteRole === ASSISTANT
 
   return (
     <div className="flex w-full justify-between p-2">
@@ -45,7 +52,11 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
       ) : (
         <div className="flex w-full justify-end">
           <Link
-            to={`/${sitename}/dashboard/edit/entries?types=story`}
+            to={
+              isAssistant // Redirect to the create page for assistants to be removed when assistants can access the edit pages (FW-4828)
+                ? `/${sitename}/dashboard/create`
+                : `/${sitename}/dashboard/edit/entries?types=story`
+            }
             className="bg-secondary hover:bg-secondary-light text-white border border-transparent rounded-lg shadow-sm py-2 px-4 inline-flex justify-center text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-secondary-light"
           >
             <span>Finish</span>


### PR DESCRIPTION
### Description of Changes
This PR updates the page redirects after an assistant successfully creates a word/phrase/song/story to the dashboard create page. This is a temporary fix until the dashboard edit page is updated to allow assistants access in FW-4828.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
