### PR TITLE
Fw-4809, set correct default visibility

### DIFF
--- a/src/common/dataAdaptors/siteAdaptors.js
+++ b/src/common/dataAdaptors/siteAdaptors.js
@@ -70,13 +70,14 @@ export function siteAdaptor({ siteData }) {
   }
 }
 
+export const formattedVisibilityOptions = (optionsArray) =>
+  optionsArray.map((option) => ({
+    icon: option,
+    value: option,
+    transKey: `visibility.${option}`,
+  }))
+
 const constructVisibilityOptions = (siteVisibility) => {
-  const formattedVisibilityOptions = (optionsArray) =>
-    optionsArray.map((option) => ({
-      icon: option,
-      value: option,
-      transKey: `visibility.${option}`,
-    }))
   switch (siteVisibility) {
     case PUBLIC:
       return formattedVisibilityOptions([PUBLIC, MEMBERS, TEAM])

--- a/src/common/hooks/useEditForm.js
+++ b/src/common/hooks/useEditForm.js
@@ -16,6 +16,7 @@ function useEditForm({ defaultValues, validator, dataToEdit }) {
     reset,
     setValue,
     trigger,
+    resetField,
   } = useForm({
     defaultValues,
     mode: 'onChange',
@@ -44,6 +45,7 @@ function useEditForm({ defaultValues, validator, dataToEdit }) {
     isValid,
     register,
     reset,
+    resetField,
     setValue,
     trigger,
   }

--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -71,12 +71,20 @@ function DictionaryCrudPresentation({
     includeInGames: 'true',
   }
 
-  const { control, errors, handleSubmit, isValid, register, reset, trigger } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    errors,
+    handleSubmit,
+    isValid,
+    register,
+    reset,
+    resetField,
+    trigger,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   const steps = [
     { title: `Add ${getFriendlyDocType({ docType: type })} content` },
@@ -281,7 +289,11 @@ function DictionaryCrudPresentation({
         return (
           <Fragment key={step}>
             <div className="col-span-12">
-              <Form.Visibility control={control} errors={errors} />
+              <Form.Visibility
+                control={control}
+                errors={errors}
+                resetField={resetField}
+              />
             </div>
             <div className="col-span-12">
               <Form.RadioButtons

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -12,6 +12,7 @@ function Visibility({
   control,
   errors,
   label = 'Who can see this entry?',
+  resetField,
 } = {}) {
   const { site } = useSiteStore()
   const { user } = useUserStore()
@@ -26,8 +27,14 @@ function Visibility({
     return site?.visibilityOptions
   })()
 
+  useEffect(() => {
+    // set default value to match visibility options
+    resetField('visibility', { defaultValue: options[0]?.value })
+  }, [options, resetField])
+
   return (
-    site?.visibilityOptions && (
+    site?.visibilityOptions &&
+    userSiteRole && (
       <Fragment key="FormVisibility">
         <Select
           label={label}
@@ -43,11 +50,12 @@ function Visibility({
   )
 }
 // PROPTYPES
-const { object, string } = PropTypes
+const { func, object, string } = PropTypes
 Visibility.propTypes = {
   label: string,
   control: object,
   errors: object,
+  resetField: func,
 }
 
 export default Visibility

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types'
 import Select from 'components/Form/Select'
 import { useSiteStore } from 'context/SiteContext'
 import { useUserStore } from 'context/UserContext'
-import { ASSISTANT } from '../../common/constants/roles'
+import { TEAM, ASSISTANT } from 'common/constants'
+import { formattedVisibilityOptions } from 'common/dataAdaptors/siteAdaptors'
 
 function Visibility({
   control,
@@ -20,12 +21,7 @@ function Visibility({
 
   const options = (function _() {
     if (isAssistant) {
-      const optionsLen = site?.visibilityOptions.length
-      for (let i = 0; i < optionsLen; i += 1) {
-        if (site?.visibilityOptions[i]?.value !== 'team') {
-          site?.visibilityOptions.splice(i, 1)
-        }
-      }
+      return formattedVisibilityOptions([TEAM])
     }
     return site?.visibilityOptions
   })()

--- a/src/components/PageCrud/PageForm.js
+++ b/src/components/PageCrud/PageForm.js
@@ -29,12 +29,19 @@ function PageForm({ cancelHandler, dataToEdit, submitHandler, deleteHandler }) {
     },
   }
 
-  const { control, errors, handleSubmit, isCreateMode, register, reset } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    errors,
+    handleSubmit,
+    isCreateMode,
+    register,
+    reset,
+    resetField,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div
@@ -133,6 +140,7 @@ function PageForm({ cancelHandler, dataToEdit, submitHandler, deleteHandler }) {
                     control={control}
                     errors={errors}
                     label="Who can see this page?"
+                    resetField={resetField}
                   />
                 </div>
               </div>

--- a/src/components/SongCrud/SongCrudPresentation.js
+++ b/src/components/SongCrud/SongCrudPresentation.js
@@ -51,12 +51,19 @@ function SongCrudPresentation({
     hideOverlay: 'false',
   }
 
-  const { control, errors, handleSubmit, isCreateMode, register, reset } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    errors,
+    handleSubmit,
+    isCreateMode,
+    register,
+    reset,
+    resetField,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div id="SongCrudPresentation" className="max-w-5xl p-8">
@@ -185,7 +192,11 @@ function SongCrudPresentation({
             />
           </div>
           <div className="col-span-12">
-            <Form.Visibility control={control} errors={errors} />
+            <Form.Visibility
+              control={control}
+              errors={errors}
+              resetField={resetField}
+            />
           </div>
           <div className="col-span-6">
             <Form.RadioButtons

--- a/src/components/StoryAudienceCrud/StoryAudienceCrudPresentation.js
+++ b/src/components/StoryAudienceCrud/StoryAudienceCrudPresentation.js
@@ -22,7 +22,7 @@ function StoryAudienceCrudPresentation({ dataToEdit, submitHandler }) {
 
   // pageOrder
 
-  const { control, errors, handleSubmit, reset } = useEditForm({
+  const { control, errors, handleSubmit, reset, resetField } = useEditForm({
     defaultValues,
     validator,
     dataToEdit,
@@ -37,7 +37,11 @@ function StoryAudienceCrudPresentation({ dataToEdit, submitHandler }) {
         <form onReset={reset}>
           <div className="grid grid-cols-12 gap-8 p-8">
             <div className="col-span-12">
-              <Form.Visibility control={control} errors={errors} />
+              <Form.Visibility
+                control={control}
+                errors={errors}
+                resetField={resetField}
+              />
             </div>
             <div className="col-span-6">
               <Form.RadioButtons

--- a/src/components/WidgetCrud/WidgetFormApps.js
+++ b/src/components/WidgetCrud/WidgetFormApps.js
@@ -28,12 +28,19 @@ function WidgetFormApps({ cancelHandler, dataToEdit, submitHandler }) {
     androidUrl: '',
   }
 
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormApps">
@@ -43,6 +50,7 @@ function WidgetFormApps({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormBase.js
+++ b/src/components/WidgetCrud/WidgetFormBase.js
@@ -13,6 +13,7 @@ function WidgetFormBase({
   errors,
   register,
   reset,
+  resetField,
   handleSubmit,
   submitHandler,
   type,
@@ -50,6 +51,7 @@ function WidgetFormBase({
               nameId="visibility"
               control={control}
               errors={errors}
+              resetField={resetField}
               label="Who can see this widget?"
             />
           </div>
@@ -81,6 +83,7 @@ WidgetFormBase.propTypes = {
   errors: object,
   register: func,
   reset: func,
+  resetField: func,
   handleSubmit: func,
 }
 

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -34,12 +34,19 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
     urls: '',
   }
 
-  const { register, handleSubmit, control, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   const { emailListAsString } = useContactUsEmailList()
 
@@ -51,6 +58,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormDefault.js
+++ b/src/components/WidgetCrud/WidgetFormDefault.js
@@ -31,12 +31,19 @@ function WidgetFormDefault({ cancelHandler, dataToEdit, submitHandler, type }) {
     visibility: PUBLIC,
   }
 
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormDefault">
@@ -46,6 +53,7 @@ function WidgetFormDefault({ cancelHandler, dataToEdit, submitHandler, type }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormGallery.js
+++ b/src/components/WidgetCrud/WidgetFormGallery.js
@@ -26,12 +26,19 @@ function WidgetFormGallery({ cancelHandler, dataToEdit, submitHandler }) {
     galleryId: '',
   }
 
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormGallery">
@@ -41,6 +48,7 @@ function WidgetFormGallery({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormKeyboards.js
+++ b/src/components/WidgetCrud/WidgetFormKeyboards.js
@@ -28,12 +28,19 @@ function WidgetFormKeyboards({ cancelHandler, dataToEdit, submitHandler }) {
     windowsUrl: '',
     chromebookUrl: '',
   }
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormKeyboards">
@@ -43,6 +50,7 @@ function WidgetFormKeyboards({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormLogo.js
+++ b/src/components/WidgetCrud/WidgetFormLogo.js
@@ -31,12 +31,19 @@ function WidgetFormLogo({ cancelHandler, dataToEdit, submitHandler }) {
     text: '',
   }
 
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormLogo">
@@ -46,6 +53,7 @@ function WidgetFormLogo({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormQuotes.js
+++ b/src/components/WidgetCrud/WidgetFormQuotes.js
@@ -42,12 +42,19 @@ function WidgetFormQuotes({ cancelHandler, dataToEdit, submitHandler }) {
     quote3By: '',
   }
 
-  const { control, register, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormQuotes">
@@ -57,6 +64,7 @@ function WidgetFormQuotes({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormText.js
+++ b/src/components/WidgetCrud/WidgetFormText.js
@@ -48,12 +48,19 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
     urlLabel: '',
   }
 
-  const { register, handleSubmit, control, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div id="WidgetFormText">
@@ -63,6 +70,7 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormTextConcise.js
+++ b/src/components/WidgetCrud/WidgetFormTextConcise.js
@@ -39,12 +39,19 @@ function WidgetFormTextConcise({ cancelHandler, dataToEdit, submitHandler }) {
     urlLabel: '',
   }
 
-  const { register, control, handleSubmit, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    register,
+    control,
+    handleSubmit,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormTextConcise">
@@ -54,6 +61,7 @@ function WidgetFormTextConcise({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormTextFull.js
+++ b/src/components/WidgetCrud/WidgetFormTextFull.js
@@ -29,12 +29,19 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
     textWithFormatting: EditorState.createEmpty(),
   }
 
-  const { register, handleSubmit, control, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormText">
@@ -44,6 +51,7 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}

--- a/src/components/WidgetCrud/WidgetFormTextIcons.js
+++ b/src/components/WidgetCrud/WidgetFormTextIcons.js
@@ -38,12 +38,19 @@ function WidgetFormTextIcons({ cancelHandler, dataToEdit, submitHandler }) {
     image: '',
   }
 
-  const { register, handleSubmit, control, reset, errors, isCreateMode } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    resetField,
+    errors,
+    isCreateMode,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   return (
     <div data-testid="WidgetFormTextIcons">
@@ -53,6 +60,7 @@ function WidgetFormTextIcons({ cancelHandler, dataToEdit, submitHandler }) {
         errors={errors}
         register={register}
         reset={reset}
+        resetField={resetField}
         handleSubmit={handleSubmit}
         submitHandler={submitHandler}
         isCreateMode={isCreateMode}


### PR DESCRIPTION
### Description of Changes

* this fixes a sneaky bug where the visibility selector would show the correct default visibility, but it wasn't actually selected, so by default the form would always submit "public" as the value
* now the visibility selector chooses the highest (first) available visibility option and resets the form field to use that as a default
* fixed for: dictionary entries, songs, stories, pages, and all widgets

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
