### PR TITLE
fw-3951, prevent undefined background image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fv-web",
-  "version": "1.0.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fv-web",
-      "version": "1.0.0",
+      "version": "0.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.23.3",

--- a/src/components/WidgetText/WidgetTextPresentation.js
+++ b/src/components/WidgetText/WidgetTextPresentation.js
@@ -57,12 +57,13 @@ function WidgetTextPresentation({ widgetData }) {
       } inline-flex items-center`}
       style={{
         backgroundImage: `url(${
-          bgImage &&
-          getMediaPath({
-            mediaObject: bgImageObject,
-            type: IMAGE,
-            size: MEDIUM,
-          })
+          bgImage
+            ? getMediaPath({
+                mediaObject: bgImageObject,
+                type: IMAGE,
+                size: MEDIUM,
+              })
+            : ''
         })`,
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'right 20% top',


### PR DESCRIPTION
### Description of Changes

- Updates the TextWithImage widget to set the background image to '' instead of undefined when no background image is selected. This avoids a failed network call to "undefined"

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
