### PR TITLE
Empty entry safeguards

### DIFF
--- a/src/common/utils/urlHelpers.js
+++ b/src/common/utils/urlHelpers.js
@@ -27,6 +27,7 @@ export const isFileType = (file, type) =>
 
 // Very basic function for making strings plural - does NOT account for variations in pluralization e.g. mouse -> mice
 export const makePlural = (string) => {
+  if (typeof string !== 'string' || string?.length < 1) return ''
   const lastCharacter = string.slice(-1)
   if (lastCharacter === 'y') {
     const plural = string.slice(0, -1)

--- a/src/components/App/AppContainer.js
+++ b/src/components/App/AppContainer.js
@@ -33,13 +33,7 @@ function AppContainer() {
           content="Indigenous Language Revitalization Platform. An online space for Indigenous communities to share and promote language, oral culture, and linguistic history."
         />
       </Helmet>
-      <Sentry.ErrorBoundary
-        fallback={
-          <AppWrapper isHome>
-            <ErrorHandler.Container />
-          </AppWrapper>
-        }
-      >
+      <Sentry.ErrorBoundary fallback={<ErrorHandler.Container />}>
         <NotificationProvider>
           <AudiobarProvider>
             <NotificationBanner />

--- a/src/components/DictionaryGridTile/DictionaryGridTilePresentationKids.js
+++ b/src/components/DictionaryGridTile/DictionaryGridTilePresentationKids.js
@@ -9,7 +9,7 @@ import AudioMinimal from 'components/AudioMinimal'
 import LazyImage from 'components/LazyImage'
 
 function DictionaryGridTilePresentationKids({ entry }) {
-  const shortTitle = entry?.title.length < 18
+  const shortTitle = entry?.title?.length < 18
   return (
     <div
       className="w-full bg-white rounded-lg mx-auto flex justify-center relative overflow-hidden"
@@ -19,7 +19,9 @@ function DictionaryGridTilePresentationKids({ entry }) {
       <div className="absolute top-2 right-2 print:hidden">
         <Link
           className="text-fv-charcoal"
-          to={`/${entry?.sitename}/kids/${makePlural(entry.type)}/${entry.id}`}
+          to={`/${entry?.sitename}/kids/${makePlural(entry?.type)}/${
+            entry?.id
+          }`}
         >
           <span className="sr-only">Full screen</span>
           {getIcon('Fullscreen', 'fill-current h-4 w-4 hover:cursor-pointer')}
@@ -37,10 +39,10 @@ function DictionaryGridTilePresentationKids({ entry }) {
             }`}
           >
             <Link
-              key={entry.id}
+              key={entry?.id}
               className="flex items-center justify-center h-72 w-full rounded-l-lg"
-              to={`/${entry?.sitename}/kids/${makePlural(entry.type)}/${
-                entry.id
+              to={`/${entry?.sitename}/kids/${makePlural(entry?.type)}/${
+                entry?.id
               }`}
             >
               <LazyImage
@@ -66,12 +68,12 @@ function DictionaryGridTilePresentationKids({ entry }) {
               }`}
             >
               <Link
-                key={entry.id}
-                to={`/${entry?.sitename}/kids/${makePlural(entry.type)}/${
-                  entry.id
+                key={entry?.id}
+                to={`/${entry?.sitename}/kids/${makePlural(entry?.type)}/${
+                  entry?.id
                 }`}
               >
-                {entry.title}
+                {entry?.title}
               </Link>
             </div>
             {/* Translations/Definitions */}


### PR DESCRIPTION
### Description of Changes

- removed AppWrapper from Sentry.ErrorBoundary fallback - it uses Audiobar and therefore needs to be rendered inside AudiobarProvider
- Add optional chaining to all property references in entry on DictionaryGridTile - Kids
- Check for type string first in `makePlural` helper

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
