### PR TITLE
FW-5262 bug fix for wordsy key color after incorrect response

### DIFF
--- a/src/components/Game/Wordsy/Utils/Keyboard/Keyboard.js
+++ b/src/components/Game/Wordsy/Utils/Keyboard/Keyboard.js
@@ -11,13 +11,9 @@ export const getStatuses = (solution, guesses, orthographyPattern) => {
     word.forEach((letter, i) => {
       if (!solutionChars.includes(letter)) {
         charObj[letter] = 'absent'
-      }
-
-      if (letter === solutionChars[i]) {
+      } else if (letter === solutionChars[i]) {
         charObj[letter] = 'correct'
-      }
-
-      if (charObj[letter] !== 'correct') {
+      } else if (charObj[letter] !== 'correct') {
         charObj[letter] = 'present'
       }
     })


### PR DESCRIPTION
### Description of Changes
Fixed the getStatuses method to return correct status to display appropriate key color.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- ~Pull the branch and test locally~

### Additional Notes

N/A
