### PR TITLE
FW-5214 Add kids flag to parachute

### DIFF
--- a/src/common/dataHooks/useGamesSearch.js
+++ b/src/common/dataHooks/useGamesSearch.js
@@ -15,7 +15,7 @@ import {
   HAS_UNRECOGNIZED_CHARS,
 } from 'common/constants'
 
-export function useParachuteSearch({ perPage }) {
+export function useParachuteSearch({ perPage, kids }) {
   const { sitename } = useParams()
 
   const [searchParams] = useSearchParams()
@@ -30,6 +30,9 @@ export function useParachuteSearch({ perPage }) {
         [SORT]: 'random',
         [HAS_UNRECOGNIZED_CHARS]: false,
       })
+  if (kids) {
+    _searchParams.append(KIDS, kids)
+  }
   const searchParamString = _searchParams.toString()
 
   const { data, refetch } = useQuery(

--- a/src/components/Game/GamePresentation.js
+++ b/src/components/Game/GamePresentation.js
@@ -18,7 +18,7 @@ function GamePresentation({ sitename, gameId, kids }) {
 
   switch (gameId) {
     case 'parachute':
-      return <Parachute.Container />
+      return <Parachute.Container kids={kids} />
     case 'phrasescrambler':
       return <PhraseScrambler.Container kids={kids} />
     case 'wordsy':

--- a/src/components/Game/Parachute/ParachuteContainer.js
+++ b/src/components/Game/Parachute/ParachuteContainer.js
@@ -1,12 +1,13 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 // FPCC
 import Parachute from 'components/Game/Parachute'
 import Loading from 'components/Loading'
 
-function ParachuteContainer() {
+function ParachuteContainer({ kids }) {
   const { isLoading, puzzle, translation, audio, alphabet, newPuzzle } =
-    Parachute.Data()
+    Parachute.Data({ kids })
   return (
     <Loading.Container isLoading={isLoading}>
       <Parachute.Presentation
@@ -18,6 +19,11 @@ function ParachuteContainer() {
       />
     </Loading.Container>
   )
+}
+
+const { bool } = PropTypes
+ParachuteContainer.propTypes = {
+  kids: bool,
 }
 
 export default ParachuteContainer

--- a/src/components/Game/Parachute/ParachuteData.js
+++ b/src/components/Game/Parachute/ParachuteData.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 
 // FPCC
 import { useCharacters } from 'common/dataHooks/useCharacters'
@@ -7,7 +8,7 @@ import { useParachuteSearch } from 'common/dataHooks/useGamesSearch'
 const PUZZLES_PER_PAGE = 100
 const MAX_PAGES_WITHOUT_USABLE_PUZZLE = 10
 
-function ParachuteData() {
+function ParachuteData({ kids }) {
   const [currentWordIndex, setCurrentWordIndex] = useState(0)
   const [currentPuzzle, setCurrentPuzzle] = useState()
   const [pagesWithoutUsablePuzzle, setPagesWithoutUsablePuzzle] = useState(1)
@@ -18,6 +19,7 @@ function ParachuteData() {
     refetch: getNextPage,
   } = useParachuteSearch({
     perPage: PUZZLES_PER_PAGE,
+    kids,
   })
 
   const { data: characterData } = useCharacters()
@@ -68,6 +70,11 @@ function ParachuteData() {
     : {
         isLoading: true,
       }
+}
+
+const { bool } = PropTypes
+ParachuteData.propTypes = {
+  kids: bool,
 }
 
 export default ParachuteData


### PR DESCRIPTION
### Description of Changes
This PR adds the kids parameter to the search request in the parachute game when the parent GamePresentation component passes the prop.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
