### PR TITLE
FW-5214 Fix parachute error when site doesn't have a usable dictionary

### DIFF
--- a/src/common/dataHooks/useGamesSearch.js
+++ b/src/common/dataHooks/useGamesSearch.js
@@ -24,7 +24,6 @@ export function useParachuteSearch({ perPage, kids }) {
     : new URLSearchParams({
         [GAMES]: true,
         [TYPES]: TYPE_WORD,
-        [KIDS]: true,
         [HAS_AUDIO]: true,
         [HAS_TRANSLATION]: true,
         [SORT]: 'random',

--- a/src/components/Game/Parachute/ParachuteData.js
+++ b/src/components/Game/Parachute/ParachuteData.js
@@ -40,7 +40,7 @@ function ParachuteData({ kids }) {
 
   useEffect(() => {
     const getPuzzle = () => {
-      if (puzzles[currentWordIndex].length > 0) {
+      if (puzzles[currentWordIndex]?.length > 0) {
         setPagesWithoutUsablePuzzle(0)
         return puzzles[currentWordIndex]
       }
@@ -57,7 +57,7 @@ function ParachuteData({ kids }) {
     }
   }, [currentWordIndex, data])
 
-  return !!currentPuzzle && characters?.length > 0
+  return !!currentPuzzle && characters
     ? {
         isLoading: false,
         puzzle: currentPuzzle,


### PR DESCRIPTION
### Description of Changes
Fixes a minor bug which would occur when a site dictionary hasn't been recalculated. Also removes infinite loading display when a site has valid words but no characters.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
