### PR TITLE
FW-5330 Fix Temporal Stats in Stats Widget

### DIFF
--- a/src/common/dataHooks/useStats.js
+++ b/src/common/dataHooks/useStats.js
@@ -10,15 +10,7 @@ export function useStats() {
   const response = useQuery([STATS, sitename], () =>
     api.stats.get({ sitename }),
   )
-  const types = [
-    'words',
-    'phrases',
-    'songs',
-    'stories',
-    'images',
-    'audio',
-    'video',
-  ]
+  const types = ['words', 'phrases', 'songs', 'stories']
   const temporal = response?.data?.temporal
   const aggregate = response?.data?.aggregate
 


### PR DESCRIPTION
### Description of Changes

This PR removes the 3 media types from the temporal stats counter, as they were causing the stats widget to display temporal stats with blank fields.

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
