### PR TITLE
FW-5342 Set reports build your own to default to both

### DIFF
--- a/src/components/DashboardReports/DashboardReportsData.js
+++ b/src/components/DashboardReports/DashboardReportsData.js
@@ -3,7 +3,6 @@ import { useSiteStore } from 'context/SiteContext'
 import {
   TYPES,
   TYPE_DICTIONARY,
-  TYPE_WORD,
   HAS_AUDIO,
   HAS_IMAGE,
   SORT,
@@ -25,7 +24,7 @@ function DashboardReportsData() {
       icon: 'Wrench',
       name: 'Build your own',
       description: 'Use the advanced search filters to create your own report',
-      href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_WORD}`,
+      href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}`,
       iconColor: 'wordText',
       auth: EDITOR,
     },


### PR DESCRIPTION
### Description of Changes
This PR updates the reports build your own page to default to both words and phrases instead of just words.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
