### PR TITLE
FW-5409 Add include in games toggle to dictionary dashboard forms

### DIFF
--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -307,6 +307,18 @@ function DictionaryCrudPresentation({
                 ]}
               />
             </div>
+            <div className="col-span-12">
+              <Form.RadioButtons
+                label="Include in games?"
+                control={control}
+                errors={errors}
+                nameId="includeInGames"
+                options={[
+                  { label: 'Yes', value: 'true' },
+                  { label: 'No', value: 'false' },
+                ]}
+              />
+            </div>
           </Fragment>
         )
       default:


### PR DESCRIPTION
### Description of Changes

This PR adds the "include in games" option to the dictionary dashboard create and edit forms.
Note that the API was already hooked up and the toggle just needed to be re-added in the forms.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
