### PR TITLE
FW-5368 and FW-5380 Related video links support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "html-webpack-plugin": "^5.5.1",
         "i18next": "^23.7.11",
         "ky": "^0.33.3",
+        "lodash.get": "^4.4.2",
         "oidc-client-ts": "^2.2.4",
         "postcss": "^8.4.23",
         "postcss-loader": "^7.3.3",
@@ -10634,6 +10635,11 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "html-webpack-plugin": "^5.5.1",
     "i18next": "^23.7.11",
     "ky": "^0.33.3",
+    "lodash.get": "^4.4.2",
     "oidc-client-ts": "^2.2.4",
     "postcss": "^8.4.23",
     "postcss-loader": "^7.3.3",

--- a/src/common/constants/media.js
+++ b/src/common/constants/media.js
@@ -2,6 +2,7 @@
 export const AUDIO = 'audio'
 export const VIDEO = 'video'
 export const IMAGE = 'image'
+export const VIDEO_LINK = 'videoLink'
 
 // Sizes - see fv-be/firstvoices/firstvoices/settings.py
 export const ORIGINAL = 'original'

--- a/src/common/dataAdaptors/coverAdaptors.js
+++ b/src/common/dataAdaptors/coverAdaptors.js
@@ -21,7 +21,11 @@ export function coverForViewing({ item }) {
   return {
     id: item?.id || '',
     ...titleForEditing({ item }),
-    coverVisual: selectCoverMedia(item?.relatedImages, item?.relatedVideos),
+    coverVisual: selectCoverMedia(
+      item?.relatedImages,
+      item?.relatedVideos,
+      item?.relatedVideoLinks,
+    ),
     ...hideOverlayForViewing({ item }),
     ...relatedMediaForViewing({ item }),
     ...visibilityAdaptor({ item }),

--- a/src/common/dataAdaptors/relatedMediaAdaptors.js
+++ b/src/common/dataAdaptors/relatedMediaAdaptors.js
@@ -1,25 +1,41 @@
 import { objectsToIdsAdaptor } from 'common/dataAdaptors/objectsToIdsAdaptor'
 
 export function relatedMediaForViewing({ item }) {
+  const relatedVideoLinks = item?.relatedVideoLinks?.map((el) => ({
+    id: el.videoLink,
+    text: el.videoLink,
+    embedLink: el.embedLink,
+    thumbnail: el.thumbnail,
+  }))
   return {
     relatedAudio: item?.relatedAudio || [],
     relatedImages: item?.relatedImages || [],
     relatedVideos: item?.relatedVideos || [],
+    relatedVideoLinks: relatedVideoLinks || [],
   }
 }
 
 export function relatedMediaForEditing({ item }) {
+  const relatedVideoLinks = item?.relatedVideoLinks?.map((el) => ({
+    id: el.videoLink,
+    text: el.videoLink,
+    embedLink: el.embedLink,
+    thumbnail: el.thumbnail,
+  }))
   return {
     relatedAudio: objectsToIdsAdaptor(item?.relatedAudio),
     relatedImages: objectsToIdsAdaptor(item?.relatedImages),
     relatedVideos: objectsToIdsAdaptor(item?.relatedVideos),
+    relatedVideoLinks: relatedVideoLinks || [],
   }
 }
 
 export function relatedMediaForApi({ item }) {
+  const relatedVideoLinks = item?.relatedVideoLinks?.map((el) => el.text)
   return {
     related_audio: item?.relatedAudio || [],
     related_images: item?.relatedImages || [],
     related_videos: item?.relatedVideos || [],
+    related_video_links: relatedVideoLinks || [],
   }
 }

--- a/src/common/dataHooks/useCharacters.js
+++ b/src/common/dataHooks/useCharacters.js
@@ -50,6 +50,7 @@ export function useCharacters() {
     relatedAudio: character?.relatedAudio,
     relatedVideo: character?.relatedVideos?.[0] || null,
     relatedImage: character?.relatedImages?.[0] || null,
+    relatedVideoLinks: character?.relatedVideoLinks || null,
     generalNote: character?.note,
   }))
   return {

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -1,6 +1,7 @@
 import {
   IMAGE,
   VIDEO,
+  VIDEO_LINK,
   AUDIO,
   ORIGINAL,
   SMALL,
@@ -69,7 +70,11 @@ export const selectOneMediaDataHelper = (imageObj, videoObj) => {
   return {}
 }
 
-export const selectCoverMedia = (imageArray, videoArray) => {
+export const selectCoverMedia = (
+  imageArray,
+  videoArray,
+  relatedVideoLinksArray,
+) => {
   // allow for array of media objects or array of media ids
   if (imageArray?.length && imageArray?.[0]) {
     return {
@@ -81,6 +86,12 @@ export const selectCoverMedia = (imageArray, videoArray) => {
     return {
       entry: videoArray?.[0],
       type: VIDEO,
+    }
+  }
+  if (relatedVideoLinksArray?.length && relatedVideoLinksArray?.[0]) {
+    return {
+      entry: relatedVideoLinksArray?.[0],
+      type: VIDEO_LINK,
     }
   }
   return {}

--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -19,6 +19,17 @@ const stringWithMax = (charCount) =>
     .max(charCount, `Maximum length for this field is ${charCount} characters`)
     .trim()
 
+const relatedVideoLinksUrls = yup
+  .string()
+  .trim()
+  .matches(
+    /(^(https?:\/\/)?|^)(?:www.)?(?:((vimeo)\.com\/(.+))|((youtube)\.com\/watch\?v=(.+)))/,
+    {
+      message: 'Only YouTube and Vimeo links are currently supported',
+      excludeEmptyString: true,
+    },
+  )
+
 // Yup Validator Definition Helpers
 export const definitions = {
   idArray: () => yup.array().of(uuid),
@@ -88,4 +99,13 @@ export const definitions = {
         return isValid
       },
     }),
+  relatedVideoUrlsArray: () =>
+    yup.array().of(
+      yup.object({
+        text: relatedVideoLinksUrls.min(
+          1,
+          'This field cannot be empty. Remove it if you do not want to include it.',
+        ),
+      }),
+    ),
 }

--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -1,4 +1,5 @@
 import * as yup from 'yup'
+import get from 'lodash.get'
 
 // FPCC
 import { UUID_REGEX, PUBLIC, MEMBERS, TEAM } from 'common/constants'
@@ -18,6 +19,45 @@ const stringWithMax = (charCount) =>
     .string()
     .max(charCount, `Maximum length for this field is ${charCount} characters`)
     .trim()
+
+const uniquePropertyTest = function (value, propertyName, message) {
+  if (
+    this.parent
+      .filter((v) => v !== value)
+      .some((v) => get(v, propertyName) === get(value, propertyName))
+  ) {
+    throw this.createError({
+      path: `${this.path}.${propertyName}`,
+      message,
+    })
+  }
+
+  return true
+}
+yup.addMethod(yup.object, 'uniqueProperty', function (propertyName, message) {
+  return this.test('unique', message, function (value) {
+    return uniquePropertyTest.call(this, value, propertyName, message)
+  })
+})
+yup.addMethod(yup.object, 'uniqueProperties', function (propertyNames) {
+  return this.test('unique', '', function (value) {
+    const errors = propertyNames
+      .map(([propertyName, message]) => {
+        try {
+          return uniquePropertyTest.call(this, value, propertyName, message)
+        } catch (error) {
+          return error
+        }
+      })
+      .filter((error) => error instanceof yup.ValidationError)
+
+    if (errors?.length > 0) {
+      throw new yup.ValidationError(errors)
+    }
+
+    return true
+  })
+})
 
 const relatedVideoLinksUrls = yup
   .string()
@@ -101,11 +141,13 @@ export const definitions = {
     }),
   relatedVideoUrlsArray: () =>
     yup.array().of(
-      yup.object({
-        text: relatedVideoLinksUrls.min(
-          1,
-          'This field cannot be empty. Remove it if you do not want to include it.',
-        ),
-      }),
+      yup
+        .object({
+          text: relatedVideoLinksUrls.min(
+            1,
+            'This field cannot be empty. Remove it if you do not want to include it.',
+          ),
+        })
+        .uniqueProperties([['text', 'Duplicate links are not allowed.']]),
     ),
 }

--- a/src/components/Alphabet/AlphabetPresentation.js
+++ b/src/components/Alphabet/AlphabetPresentation.js
@@ -61,6 +61,7 @@ function AlphabetPresentation({
               relatedDictionaryEntries={selectedData?.relatedDictionaryEntries}
               relatedAudio={selectedData?.relatedAudio}
               relatedVideo={selectedData?.relatedVideo}
+              relatedVideoLink={selectedData?.relatedVideoLinks}
               relatedImage={selectedData?.relatedImage}
               generalNote={selectedData?.generalNote}
               onVideoClick={onVideoClick}

--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -15,6 +15,7 @@ function AlphabetPresentationSelected({
   relatedDictionaryEntries,
   relatedAudio,
   relatedVideo,
+  relatedVideoLink,
   relatedImage,
   generalNote,
   videoIsOpen,
@@ -145,7 +146,7 @@ function AlphabetPresentationSelected({
             <div className="-mr-1 ml-2 mb-1 text-3xl font-bold">{title}</div>
           </Link>
         )}
-        {relatedVideo && (
+        {(relatedVideo || relatedVideoLink?.length > 0) && (
           <button
             type="button"
             onClick={onVideoClick}
@@ -177,19 +178,33 @@ function AlphabetPresentationSelected({
                 </div>
                 {/* body */}
                 <div className="p-2">
-                  <video
-                    height="50"
-                    width="auto"
-                    src={getMediaPath({
-                      mediaObject: relatedVideo,
-                      type: VIDEO,
-                      size: ORIGINAL,
-                    })}
-                    controls
-                    autoPlay
-                  >
-                    Your browser does not support the video tag.
-                  </video>
+                  {relatedVideo && (
+                    <video
+                      height="50"
+                      width="auto"
+                      src={getMediaPath({
+                        mediaObject: relatedVideo,
+                        type: VIDEO,
+                        size: ORIGINAL,
+                      })}
+                      controls
+                      autoPlay
+                    >
+                      Your browser does not support the video tag.
+                    </video>
+                  )}
+                  {relatedVideoLink?.length > 0 && (
+                    <div className="w-[55vw] max-w-[46rem] min-w-[10rem] relative pb-[56.25%]">
+                      <iframe
+                        className="absolute t-0 l-0 w-full h-full"
+                        src={relatedVideoLink?.[0]?.embedLink}
+                        title="video"
+                        allowFullScreen
+                      >
+                        Your browser does not support the iframe tag.
+                      </iframe>
+                    </div>
+                  )}
                 </div>
               </div>
             </div>
@@ -210,6 +225,7 @@ AlphabetPresentationSelected.propTypes = {
   generalNote: string,
   relatedAudio: array,
   relatedVideo: object,
+  relatedVideoLink: object,
   relatedDictionaryEntries: array,
   onVideoClick: func,
   videoIsOpen: bool,

--- a/src/components/CharacterCrud/CharacterCrudPresentation.js
+++ b/src/components/CharacterCrud/CharacterCrudPresentation.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import * as yup from 'yup'
 
@@ -9,10 +9,15 @@ import { definitions } from 'common/utils/validationHelpers'
 import useEditForm from 'common/hooks/useEditForm'
 
 function CharacterCrudPresentation({ backHandler, dataToEdit, submitHandler }) {
+  const [currentLinks, setCurrentLinks] = useState(
+    dataToEdit?.relatedVideoLinks,
+  )
+
   const validator = yup.object().shape({
     relatedAudio: definitions.idArray(),
     relatedImages: definitions.idArray(),
     relatedVideos: definitions.idArray(),
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     relatedDictionaryEntries: definitions.objectArray(),
     generalNote: definitions.paragraph({ charCount: 120 }),
   })
@@ -21,15 +26,25 @@ function CharacterCrudPresentation({ backHandler, dataToEdit, submitHandler }) {
     relatedAudio: [],
     relatedImages: [],
     relatedVideos: [],
+    relatedVideoLinks: [],
     relatedDictionaryEntries: [],
     generalNote: '',
   }
 
-  const { control, errors, handleSubmit, register, reset } = useEditForm({
-    defaultValues,
-    validator,
-    dataToEdit,
-  })
+  const { control, errors, handleSubmit, register, reset, setValue } =
+    useEditForm({
+      defaultValues,
+      validator,
+      dataToEdit,
+    })
+
+  useEffect(() => {
+    setCurrentLinks(dataToEdit?.relatedVideoLinks)
+  }, [dataToEdit?.relatedVideoLinks])
+
+  useEffect(() => {
+    setValue('relatedVideoLinks', currentLinks)
+  }, [currentLinks])
 
   return (
     <div id="CharacterCrudPresentation" className="max-w-5xl p-8">
@@ -90,6 +105,9 @@ function CharacterCrudPresentation({ backHandler, dataToEdit, submitHandler }) {
               control={control}
               type={VIDEO}
               maxItems={1}
+              relatedVideoLinks={dataToEdit?.relatedVideoLinks}
+              currentLinks={currentLinks}
+              setCurrentLinks={setCurrentLinks}
             />
             {errors?.relatedVideos && (
               <div className="text-red-500">

--- a/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
+++ b/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
@@ -69,7 +69,9 @@ function DashboardAlphabetPresentation({
               </td>
               <td className="px-6 py-4 whitespace-nowrap text-fv-charcoal">
                 <div className="flex justify-center">
-                  {getIndicatorIcon(character?.relatedVideo)}
+                  {character?.relatedVideo
+                    ? getIndicatorIcon(character?.relatedVideo)
+                    : getIndicatorIcon(character?.relatedVideoLinks)}
                 </div>
               </td>
               <td className="px-6 py-4 whitespace-nowrap text-fv-charcoal">

--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { Fragment } from 'react'
+import React, { Fragment, useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import * as yup from 'yup'
 
@@ -29,6 +29,10 @@ function DictionaryCrudPresentation({
   isCreate,
   partsOfSpeech,
 }) {
+  const [currentLinks, setCurrentLinks] = useState(
+    dataToEdit?.relatedVideoLinks,
+  )
+
   const [activeStep, setActiveStep] = useSearchParamsState({
     searchParamName: 'step',
     defaultValue: '0',
@@ -46,6 +50,7 @@ function DictionaryCrudPresentation({
     relatedEntries: definitions.objectArray(),
     relatedImages: definitions.idArray(),
     relatedVideos: definitions.idArray(),
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     title: definitions
       .title({ charCount: 225 })
       .required('You must enter at least 1 character in this field.'),
@@ -63,6 +68,7 @@ function DictionaryCrudPresentation({
     relatedEntries: [],
     relatedImages: [],
     relatedVideos: [],
+    relatedVideoLinks: [],
     title: '',
     type: type || TYPE_WORD,
     translations: [],
@@ -79,6 +85,7 @@ function DictionaryCrudPresentation({
     register,
     reset,
     resetField,
+    setValue,
     trigger,
   } = useEditForm({
     defaultValues,
@@ -114,6 +121,10 @@ function DictionaryCrudPresentation({
   const onFinishClick = () => {
     if (activeStepNumber !== lastStep) stepHandle(lastStep)
   }
+
+  useEffect(() => {
+    setValue('relatedVideoLinks', currentLinks)
+  }, [currentLinks])
 
   function getStepContent(step) {
     switch (Number(step)) {
@@ -239,6 +250,9 @@ function DictionaryCrudPresentation({
                 register={register}
                 type={VIDEO}
                 maxItems={10}
+                relatedVideoLinks={dataToEdit?.relatedVideoLinks}
+                currentLinks={currentLinks}
+                setCurrentLinks={setCurrentLinks}
               />
               {errors?.relatedVideos && (
                 <div className="text-red-500">

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -22,7 +22,9 @@ function DictionaryDetailPresentation({
     'text-left font-medium text-lg uppercase text-fv-charcoal'
   const contentStyling = 'text-fv-charcoal sm:mt-0 sm:ml-6 sm:col-span-2'
   const noMedia = !(
-    entry?.relatedImages?.length > 0 || entry?.relatedVideos?.length > 0
+    entry?.relatedImages?.length > 0 ||
+    entry?.relatedVideos?.length > 0 ||
+    entry?.relatedVideoLinks?.length > 0
   )
   const shortTitle = entry?.title.length < 20
 
@@ -264,6 +266,22 @@ function DictionaryDetailPresentation({
                           )}
                         </Disclosure.Panel>
                       </Disclosure>
+                    </li>
+                  ))
+                : null}
+              {entry?.relatedVideoLinks
+                ? entry?.relatedVideoLinks?.map((video) => (
+                    <li key={video.id} className="my-2 p-3">
+                      <div className="rounded-lg relative pb-[56.25%] h-0">
+                        <iframe
+                          className="rounded-lg absolute t-0 l-0 w-full h-full"
+                          src={video?.embedLink}
+                          title="video"
+                          allowFullScreen
+                        >
+                          Your browser does not support the iframe tag.
+                        </iframe>
+                      </div>
                     </li>
                   ))
                 : null}

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -205,7 +205,10 @@ function DictionaryDetailPresentationDrawer({
                 : null}
               {entry?.relatedVideoLinks
                 ? entry?.relatedVideoLinks?.map((video) => (
-                    <div className="rounded-lg relative pb-[56.25%] h-0">
+                    <div
+                      key={video?.id}
+                      className="rounded-lg relative pb-[56.25%] h-0"
+                    >
                       <iframe
                         className="rounded-lg absolute t-0 l-0 w-full h-full"
                         src={video?.embedLink}

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -22,7 +22,9 @@ function DictionaryDetailPresentationDrawer({
     'text-left font-medium text-lg uppercase text-fv-charcoal'
   const contentStyling = 'text-sm text-fv-charcoal sm:mt-0 sm:ml-6'
   const noMedia = !(
-    entry?.relatedImages?.length > 0 || entry?.relatedVideos?.length > 0
+    entry?.relatedImages?.length > 0 ||
+    entry?.relatedVideos?.length > 0 ||
+    entry?.relatedVideoLinks?.length > 0
   )
   const shortTitle = entry?.title.length < 16
   return (
@@ -198,6 +200,20 @@ function DictionaryDetailPresentationDrawer({
                           )}
                         </Disclosure.Panel>
                       </Disclosure>
+                    </div>
+                  ))
+                : null}
+              {entry?.relatedVideoLinks
+                ? entry?.relatedVideoLinks?.map((video) => (
+                    <div className="rounded-lg relative pb-[56.25%] h-0">
+                      <iframe
+                        className="rounded-lg absolute t-0 l-0 w-full h-full"
+                        src={video?.embedLink}
+                        title="video"
+                        allowFullScreen
+                      >
+                        Your browser does not support the iframe tag.
+                      </iframe>
                     </div>
                   ))
                 : null}

--- a/src/components/Form/FieldButton.js
+++ b/src/components/Form/FieldButton.js
@@ -4,12 +4,24 @@ import PropTypes from 'prop-types'
 // FPCC
 import getIcon from 'common/utils/getIcon'
 
-function FieldButton({ label, openModal, append }) {
+function FieldButton({
+  label,
+  openModal,
+  append,
+  setDisableMediaLibraryButton,
+}) {
   return (
     <div>
       <button
         type="button"
-        onClick={openModal ? () => openModal() : () => append({ text: '' })}
+        onClick={
+          openModal
+            ? () => openModal()
+            : () => {
+                append({ text: '' })
+                setDisableMediaLibraryButton(true)
+              }
+        }
         className="bg-white border-2 border-primary text-primary hover:bg-gray-50 rounded-lg shadow-sm py-2 px-4 inline-flex justify-center text-sm font-medium  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-secondary-light"
       >
         {getIcon('Add', 'fill-current -ml-1 mr-2 h-5 w-5')}
@@ -25,6 +37,11 @@ FieldButton.propTypes = {
   label: string,
   openModal: func,
   append: func,
+  setDisableMediaLibraryButton: func,
+}
+
+FieldButton.defaultProps = {
+  setDisableMediaLibraryButton: () => {},
 }
 
 export default FieldButton

--- a/src/components/Form/MediaArrayField.js
+++ b/src/components/Form/MediaArrayField.js
@@ -49,7 +49,7 @@ function MediaArrayField({
         {label}
       </label>
       <div className="space-y-2 mt-2">
-        {type === VIDEO && value?.length > 0 && (
+        {type === VIDEO && value?.length > 0 && currentLinks?.length > 0 && (
           <p className="block text-sm font-small text-fv-charcoal italic">
             Uploaded Videos
           </p>
@@ -87,7 +87,7 @@ function MediaArrayField({
         </div>
         {type === VIDEO && currentLinks?.length > 0 && (
           <p className="block text-sm font-small text-fv-charcoal italic">
-            Video Links
+            Linked Videos
           </p>
         )}
         {type === VIDEO &&
@@ -130,14 +130,12 @@ function MediaArrayField({
               })}
               {numNewLinks === 1 && (
                 <p className="block text-sm font-small text-fv-charcoal italic">
-                  Plus {numNewLinks} new link (thumbnails will be generated on
-                  save).
+                  {numNewLinks} new link will be added when you save.
                 </p>
               )}
               {numNewLinks > 1 && (
                 <p className="block text-sm font-small text-fv-charcoal italic">
-                  Plus {numNewLinks} new links (thumbnails will be generated on
-                  save).
+                  {numNewLinks} new links will be added when you save.
                 </p>
               )}
             </div>

--- a/src/components/Form/TextArrayField.js
+++ b/src/components/Form/TextArrayField.js
@@ -14,6 +14,7 @@ function TextArrayField({
   register,
   control,
   errors,
+  hideLabel,
 }) {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -28,9 +29,11 @@ function TextArrayField({
 
   return (
     <Fragment key={`${nameId}_TextArrayField`}>
-      <label className="block text-sm font-medium text-fv-charcoal">
-        {label}
-      </label>
+      {!hideLabel && (
+        <label className="block text-sm font-medium text-fv-charcoal">
+          {label}
+        </label>
+      )}
       <div className="space-y-2 mt-2">
         <ul className="space-y-2">
           {fields.map((item, index) => (
@@ -43,7 +46,7 @@ function TextArrayField({
                   onKeyDown={handleKeyDown}
                 />
                 <div className="has-tooltip flex items-center">
-                  <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-12">
+                  <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-24">
                     Delete {label.slice(0, -1)}
                   </span>
                   <button
@@ -79,7 +82,7 @@ function TextArrayField({
 }
 
 // PROPTYPES
-const { func, number, object, string } = PropTypes
+const { func, number, object, string, bool } = PropTypes
 TextArrayField.propTypes = {
   helpText: string,
   label: string,
@@ -88,6 +91,7 @@ TextArrayField.propTypes = {
   maxItems: number,
   register: func,
   errors: object,
+  hideLabel: bool,
 }
 
 TextArrayField.defaultProps = {

--- a/src/components/Form/TextArrayField.js
+++ b/src/components/Form/TextArrayField.js
@@ -16,6 +16,7 @@ function TextArrayField({
   errors,
   hideLabel,
   setDisableMediaLibraryButton,
+  placeholder,
 }) {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -42,9 +43,10 @@ function TextArrayField({
               <div className="flex items-center w-full justify-between pr-3 border border-gray-300 shadow-sm bg-white rounded-lg focus:outline-none focus:ring-secondary focus:border-secondary">
                 <input
                   type="text"
-                  className="flex w-full py-2 border border-white focus:outline-none focus:ring-secondary focus:border-secondary rounded-lg"
+                  className="flex w-full py-2 border border-white focus:outline-none focus:ring-secondary focus:border-secondary rounded-lg placeholder:italic"
                   {...register(`${nameId}.${index}.text`)}
                   onKeyDown={handleKeyDown}
+                  placeholder={placeholder}
                 />
                 <div className="has-tooltip flex items-center">
                   <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-24">
@@ -101,12 +103,14 @@ TextArrayField.propTypes = {
   errors: object,
   hideLabel: bool,
   setDisableMediaLibraryButton: func,
+  placeholder: string,
 }
 
 TextArrayField.defaultProps = {
   label: '',
   maxItems: 10,
   setDisableMediaLibraryButton: () => {},
+  placeholder: null,
 }
 
 export default TextArrayField

--- a/src/components/Form/TextArrayField.js
+++ b/src/components/Form/TextArrayField.js
@@ -15,6 +15,7 @@ function TextArrayField({
   control,
   errors,
   hideLabel,
+  setDisableMediaLibraryButton,
 }) {
   const { fields, append, remove } = useFieldArray({
     control,
@@ -54,7 +55,10 @@ function TextArrayField({
                     type="button"
                     aria-label={`Delete ${label.slice(0, -1)}`}
                     className="inline-flex"
-                    onClick={() => remove(index)}
+                    onClick={() => {
+                      remove(index)
+                      setDisableMediaLibraryButton(true)
+                    }}
                   >
                     {getIcon('Trash', 'fill-current h-5 w-5 ml-2')}
                   </button>
@@ -71,7 +75,11 @@ function TextArrayField({
           ))}
         </ul>
         {fields?.length < maxItems && (
-          <FieldButton label={label} append={append} />
+          <FieldButton
+            label={label}
+            append={append}
+            setDisableMediaLibraryButton={setDisableMediaLibraryButton}
+          />
         )}
       </div>
       {helpText && (
@@ -92,11 +100,13 @@ TextArrayField.propTypes = {
   register: func,
   errors: object,
   hideLabel: bool,
+  setDisableMediaLibraryButton: func,
 }
 
 TextArrayField.defaultProps = {
   label: '',
   maxItems: 10,
+  setDisableMediaLibraryButton: () => {},
 }
 
 export default TextArrayField

--- a/src/components/MediaCrud/MediaCrudContainer.js
+++ b/src/components/MediaCrud/MediaCrudContainer.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import MediaCrudData from 'components/MediaCrud/MediaCrudData'
 import UploadMedia from 'components/MediaCrud/UploadMedia'
 import SelectMedia from 'components/MediaCrud/SelectMedia'
+import VideoLinks from 'components/MediaCrud/VideoLinks'
 import { AUDIO, IMAGE, VIDEO } from 'common/constants'
 import { makeTitleCase } from 'common/utils/stringHelpers'
 
@@ -13,6 +14,9 @@ function MediaCrudContainer({
   updateSavedMedia,
   docType,
   maxFiles,
+  currentLinks,
+  setCurrentLinks,
+  closeModal,
 }) {
   const {
     searchValue,
@@ -60,7 +64,6 @@ function MediaCrudContainer({
       </button>
     )
   }
-
   return (
     <div
       id="MediaCrudContainer"
@@ -91,17 +94,28 @@ function MediaCrudContainer({
             {makeTitleCase(docTypeLabelPlural)}
           </button>
         )}
+        {docType === VIDEO && (
+          <button
+            type="button"
+            className={`${buttonStyles} ml-2 hover:bg-primary-light`}
+            onClick={() => setSelectedTab(`Video Links`)}
+          >
+            Video Links
+          </button>
+        )}
         <button
           type="button"
           className={`${buttonStyles} mx-2 hover:bg-fv-warning-red`}
           onClick={() => clearSelectedMedia()}
-          disabled={selectedTab === 'Upload Files'}
+          disabled={
+            selectedTab === 'Upload Files' || selectedTab === 'Video Links'
+          }
         >
           Clear Selection
         </button>
       </div>
       <div className="grow mt-2">
-        {selectedTab === 'Media Library' ? (
+        {selectedTab === 'Media Library' && (
           <SelectMedia
             docType={docType}
             searchValue={searchValue}
@@ -117,13 +131,22 @@ function MediaCrudContainer({
             loadLabel={loadLabel}
             docTypeLabelPlural={docTypeLabelPlural}
           />
-        ) : (
+        )}
+        {selectedTab === 'Upload Files' && (
           <UploadMedia
             docType={docType}
             site={site}
             extensionList={extensionList}
             setSelectedMedia={setSelectedMedia}
             maxFiles={maxFiles}
+          />
+        )}
+        {selectedTab === 'Video Links' && (
+          <VideoLinks
+            currentLinks={currentLinks}
+            setCurrentLinks={setCurrentLinks}
+            closeModal={closeModal}
+            maxLinks={maxFiles}
           />
         )}
       </div>
@@ -138,6 +161,9 @@ MediaCrudContainer.propTypes = {
   updateSavedMedia: func,
   docType: oneOf([AUDIO, IMAGE, VIDEO]),
   maxFiles: number,
+  currentLinks: array,
+  setCurrentLinks: func,
+  closeModal: func,
 }
 
 export default MediaCrudContainer

--- a/src/components/MediaCrud/MediaCrudContainer.js
+++ b/src/components/MediaCrud/MediaCrudContainer.js
@@ -51,6 +51,9 @@ function MediaCrudContainer({
     }
   }, [selectedMedia])
 
+  const [disableMediaLibraryButton, setDisableMediaLibraryButton] =
+    useState(false)
+
   const switchTabButton = () => {
     const switchToTab =
       selectedTab === 'Media Library' ? 'Upload Files' : 'Media Library'
@@ -59,6 +62,7 @@ function MediaCrudContainer({
         type="button"
         className={`${buttonStyles} hover:bg-primary-light`}
         onClick={() => setSelectedTab(`${switchToTab}`)}
+        disabled={disableMediaLibraryButton}
       >
         {switchToTab}
       </button>
@@ -99,8 +103,9 @@ function MediaCrudContainer({
             type="button"
             className={`${buttonStyles} ml-2 hover:bg-primary-light`}
             onClick={() => setSelectedTab(`Video Links`)}
+            disabled={!allowSwitchTab}
           >
-            Video Links
+            Link a Video
           </button>
         )}
         <button
@@ -147,6 +152,7 @@ function MediaCrudContainer({
             setCurrentLinks={setCurrentLinks}
             closeModal={closeModal}
             maxLinks={maxFiles}
+            setDisableMediaLibraryButton={setDisableMediaLibraryButton}
           />
         )}
       </div>

--- a/src/components/MediaCrud/VideoLinks.js
+++ b/src/components/MediaCrud/VideoLinks.js
@@ -70,6 +70,7 @@ function VideoLinks({
           maxItems={maxLinks}
           hideLabel
           setDisableMediaLibraryButton={setDisableMediaLibraryButton}
+          placeholder="Example links: https://www.youtube.com/watch?v=A1B2C3D4E5F or https://vimeo.com/123456789"
         />
         <button
           type="button"

--- a/src/components/MediaCrud/VideoLinks.js
+++ b/src/components/MediaCrud/VideoLinks.js
@@ -1,0 +1,88 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import * as yup from 'yup'
+
+// FPCC
+import Form from 'components/Form'
+import { definitions } from 'common/utils/validationHelpers'
+import useEditForm from 'common/hooks/useEditForm'
+
+function VideoLinks({ currentLinks, setCurrentLinks, closeModal, maxLinks }) {
+  const relatedVideoLinks = currentLinks
+  const dataToEdit = {
+    relatedVideoLinks,
+  }
+
+  const validator = yup.object().shape({
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
+  })
+
+  const defaultValues = {
+    relatedVideoLinks,
+  }
+
+  const { control, errors, handleSubmit, register, reset } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
+
+  const submitHandler = (formData) => {
+    const relatedMediaLinks = formData?.relatedVideoLinks
+    if (!relatedMediaLinks) {
+      return
+    }
+
+    setCurrentLinks(relatedMediaLinks)
+    closeModal()
+  }
+
+  const buttonStyles =
+    'my-2 w-1/5 border-2 border-wordText rounded-md py-2 px-4 hover:text-white disabled:pointer-events-none disabled:bg-tertiaryB-light disabled:opacity-50'
+
+  return (
+    <form onReset={reset}>
+      <div className="col-span-12">
+        {maxLinks === 1 && (
+          <p className="block text-sm font-small text-fv-charcoal italic">
+            Add up to {maxLinks} video link below (currently YouTube and Vimeo
+            links are supported).
+          </p>
+        )}
+        {maxLinks > 1 && (
+          <p className="block text-sm font-small text-fv-charcoal italic">
+            Add up to {maxLinks} video links below (currently YouTube and Vimeo
+            links are supported).
+          </p>
+        )}
+        <Form.TextArrayField
+          label="Video links"
+          nameId="relatedVideoLinks"
+          register={register}
+          control={control}
+          errors={errors}
+          maxItems={maxLinks}
+          hideLabel
+        />
+        <button
+          type="button"
+          className={`${buttonStyles} bg-primary hover:bg-primary-dark text-white`}
+          onClick={handleSubmit(submitHandler)}
+        >
+          Insert Video Links
+        </button>
+      </div>
+    </form>
+  )
+}
+
+const { array, func, number } = PropTypes
+
+VideoLinks.propTypes = {
+  currentLinks: array,
+  setCurrentLinks: func,
+  closeModal: func,
+  maxLinks: number,
+}
+
+export default VideoLinks

--- a/src/components/MediaCrud/VideoLinks.js
+++ b/src/components/MediaCrud/VideoLinks.js
@@ -7,7 +7,13 @@ import Form from 'components/Form'
 import { definitions } from 'common/utils/validationHelpers'
 import useEditForm from 'common/hooks/useEditForm'
 
-function VideoLinks({ currentLinks, setCurrentLinks, closeModal, maxLinks }) {
+function VideoLinks({
+  currentLinks,
+  setCurrentLinks,
+  closeModal,
+  maxLinks,
+  setDisableMediaLibraryButton,
+}) {
   const relatedVideoLinks = currentLinks
   const dataToEdit = {
     relatedVideoLinks,
@@ -63,13 +69,14 @@ function VideoLinks({ currentLinks, setCurrentLinks, closeModal, maxLinks }) {
           errors={errors}
           maxItems={maxLinks}
           hideLabel
+          setDisableMediaLibraryButton={setDisableMediaLibraryButton}
         />
         <button
           type="button"
           className={`${buttonStyles} bg-primary hover:bg-primary-dark text-white`}
           onClick={handleSubmit(submitHandler)}
         >
-          Insert Video Links
+          Update Linked Videos
         </button>
       </div>
     </form>
@@ -83,6 +90,7 @@ VideoLinks.propTypes = {
   setCurrentLinks: func,
   closeModal: func,
   maxLinks: number,
+  setDisableMediaLibraryButton: func,
 }
 
 export default VideoLinks

--- a/src/components/MediaThumbnail/VideoLinkThumbnail.js
+++ b/src/components/MediaThumbnail/VideoLinkThumbnail.js
@@ -5,11 +5,7 @@ function VideoLinkThumbnail(props) {
   const { link } = props
   return (
     <div className="block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
-      <img
-        src={link?.thumbnail}
-        alt="video thumbnail"
-        className="group-hover:opacity-75 object-cover pointer-events-none"
-      />
+      <iframe src={link?.embedLink} title="video" />
     </div>
   )
 }

--- a/src/components/MediaThumbnail/VideoLinkThumbnail.js
+++ b/src/components/MediaThumbnail/VideoLinkThumbnail.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+function VideoLinkThumbnail(props) {
+  const { link } = props
+  return (
+    <div className="block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
+      <img
+        src={link?.thumbnail}
+        alt="video thumbnail"
+        className="group-hover:opacity-75 object-cover pointer-events-none"
+      />
+    </div>
+  )
+}
+
+const { object } = PropTypes
+VideoLinkThumbnail.propTypes = {
+  link: object,
+}
+
+export default VideoLinkThumbnail

--- a/src/components/MediaThumbnail/VideoLinkThumbnail.js
+++ b/src/components/MediaThumbnail/VideoLinkThumbnail.js
@@ -2,17 +2,27 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 function VideoLinkThumbnail(props) {
-  const { link } = props
+  const { link, containerStyles } = props
   return (
-    <div className="block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
-      <iframe src={link?.embedLink} title="video" />
+    <div className={containerStyles}>
+      <img
+        src={link?.thumbnail}
+        alt="video thumbnail"
+        className="group-hover:opacity-75 object-cover pointer-events-none"
+      />
     </div>
   )
 }
 
-const { object } = PropTypes
+const { object, string } = PropTypes
 VideoLinkThumbnail.propTypes = {
   link: object,
+  containerStyles: string,
+}
+
+VideoLinkThumbnail.defaultProps = {
+  containerStyles:
+    'block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden',
 }
 
 export default VideoLinkThumbnail

--- a/src/components/MediaThumbnail/index.js
+++ b/src/components/MediaThumbnail/index.js
@@ -1,6 +1,7 @@
 import ImageThumbnail from 'components/MediaThumbnail/ImageThumbnail'
 import VideoThumbnail from 'components/MediaThumbnail/VideoThumbnail'
 import AudioThumbnail from 'components/MediaThumbnail/AudioThumbnail'
+import VideoLinkThumbnail from 'components/MediaThumbnail/VideoLinkThumbnail'
 
 // Only presentation layers are present in MediaThumbnail component,
 // Skipping the default structure of container, data and presentation layers.
@@ -8,4 +9,5 @@ export default {
   Audio: AudioThumbnail,
   Image: ImageThumbnail,
   Video: VideoThumbnail,
+  VideoLink: VideoLinkThumbnail,
 }

--- a/src/components/Song/SongPresentation.js
+++ b/src/components/Song/SongPresentation.js
@@ -156,7 +156,7 @@ const getMedia = ({ pictures, videos, videoLinks, videoLinksClassname }) => (
     {videoLinks?.length > 0 && (
       <div className="space-y-4">
         {videoLinks?.map((video) => (
-          <div className={videoLinksClassname}>
+          <div key={video.id} className={videoLinksClassname}>
             <div className="relative pb-[56.25%] h-0">
               <iframe
                 className="absolute t-0 l-0 w-full h-full"

--- a/src/components/Song/SongPresentation.js
+++ b/src/components/Song/SongPresentation.js
@@ -10,7 +10,9 @@ import { VIDEO, ORIGINAL } from 'common/constants'
 
 function SongPresentation({ entry }) {
   const hasMedia = !!(
-    entry?.relatedImages.length > 0 || entry?.relatedVideos?.length > 0
+    entry?.relatedImages.length > 0 ||
+    entry?.relatedVideos?.length > 0 ||
+    entry?.relatedVideoLinks?.length > 0
   )
   const labelStyling = 'font-bold text-fv-charcoal uppercase'
   const contentStyling = 'text-fv-charcoal sm:mt-0 sm:ml-6'
@@ -26,6 +28,8 @@ function SongPresentation({ entry }) {
               {getMedia({
                 pictures: entry?.relatedImages,
                 videos: entry?.relatedVideos,
+                videoLinks: entry?.relatedVideoLinks,
+                videoLinksClassname: 'w-[25vw] max-w-[378px]',
               })}
             </div>
           )}
@@ -110,6 +114,8 @@ function SongPresentation({ entry }) {
                 {getMedia({
                   pictures: entry?.relatedImages,
                   videos: entry?.relatedVideos,
+                  videoLinks: entry?.relatedVideoLinks,
+                  videoLinksClassname: 'w-[95vw] pr-[2.5rem]',
                 })}
               </div>
             )}
@@ -120,7 +126,7 @@ function SongPresentation({ entry }) {
   )
 }
 
-const getMedia = ({ pictures, videos }) => (
+const getMedia = ({ pictures, videos, videoLinks, videoLinksClassname }) => (
   <div className="space-y-4">
     {pictures.length > 0 && (
       <div className="space-y-4">
@@ -144,6 +150,24 @@ const getMedia = ({ pictures, videos }) => (
           >
             Your browser does not support the video tag.
           </video>
+        ))}
+      </div>
+    )}
+    {videoLinks?.length > 0 && (
+      <div className="space-y-4">
+        {videoLinks?.map((video) => (
+          <div className={videoLinksClassname}>
+            <div className="relative pb-[56.25%] h-0">
+              <iframe
+                className="absolute t-0 l-0 w-full h-full"
+                src={video?.embedLink}
+                title="video"
+                allowFullScreen
+              >
+                Your browser does not support the iframe tag.
+              </iframe>
+            </div>
+          </div>
         ))}
       </div>
     )}

--- a/src/components/Song/SongPresentationDrawer.js
+++ b/src/components/Song/SongPresentationDrawer.js
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import AudioNative from 'components/AudioNative'
 import WysiwygBlock from 'components/WysiwygBlock'
-import { IMAGE, VIDEO, SMALL, ORIGINAL } from 'common/constants'
+import { IMAGE, VIDEO, VIDEO_LINK, SMALL, ORIGINAL } from 'common/constants'
 
 function SongPresentationDrawer({ entry, sitename }) {
   return (
@@ -53,6 +53,18 @@ function SongPresentationDrawer({ entry, sitename }) {
           >
             Your browser does not support the video tag.
           </video>
+        </div>
+      )}
+      {entry.coverVisual?.type === VIDEO_LINK && (
+        <div className="my-2 md:my-6 mx-auto px-4 relative pb-[56.25%] h-0">
+          <iframe
+            className="pr-8 absolute t-0 l-0 w-full h-full mx-auto"
+            src={entry?.coverVisual?.entry?.embedLink}
+            title="video"
+            allowFullScreen
+          >
+            Your browser does not support the iframe tag.
+          </iframe>
         </div>
       )}
       <div className="flex px-6 mt-2 md:mt-6">

--- a/src/components/SongCrud/SongCrudPresentation.js
+++ b/src/components/SongCrud/SongCrudPresentation.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import * as yup from 'yup'
 import { EditorState } from 'draft-js'
@@ -16,6 +16,10 @@ function SongCrudPresentation({
   deleteHandler,
   submitHandler,
 }) {
+  const [currentLinks, setCurrentLinks] = useState(
+    dataToEdit?.relatedVideoLinks,
+  )
+
   const validator = yup.object().shape({
     title: definitions.title().required('A title is required'),
     titleTranslation: definitions.paragraph(),
@@ -32,6 +36,7 @@ function SongCrudPresentation({
     relatedAudio: definitions.idArray(),
     relatedImages: definitions.idArray(),
     relatedVideos: definitions.idArray(),
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
   })
 
   const defaultValues = {
@@ -45,6 +50,7 @@ function SongCrudPresentation({
     relatedAudio: [],
     relatedImages: [],
     relatedVideos: [],
+    relatedVideoLinks: [],
     includeInKids: 'true',
     includeInGames: 'true',
     visibility: PUBLIC,
@@ -59,11 +65,16 @@ function SongCrudPresentation({
     register,
     reset,
     resetField,
+    setValue,
   } = useEditForm({
     defaultValues,
     validator,
     dataToEdit,
   })
+
+  useEffect(() => {
+    setValue('relatedVideoLinks', currentLinks)
+  }, [currentLinks])
 
   return (
     <div id="SongCrudPresentation" className="max-w-5xl p-8">
@@ -164,6 +175,9 @@ function SongCrudPresentation({
               register={register}
               type={VIDEO}
               maxItems={10}
+              relatedVideoLinks={dataToEdit?.relatedVideoLinks}
+              currentLinks={currentLinks}
+              setCurrentLinks={setCurrentLinks}
             />
             {errors?.relatedVideos && (
               <div className="text-red-500">

--- a/src/components/Story/StoryPresentation.js
+++ b/src/components/Story/StoryPresentation.js
@@ -272,7 +272,7 @@ function StoryPresentation({ entry }) {
 }
 
 const getMedia = ({ images = [], videos = [], videoLinks = [] }) => {
-  const media = images.length + videos.length + videoLinks.length
+  const mediaLength = images.length + videos.length + videoLinks.length
 
   const getImageTag = ({ image, className }) => (
     <img
@@ -316,90 +316,92 @@ const getMedia = ({ images = [], videos = [], videoLinks = [] }) => {
     </div>
   )
 
-  if (images.length === 1 && media === 1) {
-    return (
-      <div className="w-full md:w-6/12">
-        {getImageTag({
-          image: images?.[0],
-          className: 'h-auto w-full',
-        })}
-      </div>
-    )
-  }
-  if (videos.length === 1 && media === 1) {
-    return (
-      <div className="w-full md:w-6/12 flex-none">
-        {getVideoTag({ video: videos?.[0], className: 'h-auto w-full' })}
-      </div>
-    )
-  }
-  if (videoLinks.length === 1 && media === 1) {
-    return (
-      <div className="w-full md:w-6/12 flex-none">
-        {getVideoLinkTag({
-          videoLink: videoLinks?.[0],
-          className: 'h-auto w-full',
-        })}
-      </div>
-    )
-  }
-  if (media === 2) {
-    return (
-      <div className="w-full md:w-6/12">
-        <div className="grid grid-cols-2 gap-4 m-4">
-          {images.length > 0
-            ? images?.map((image) =>
-                getImageTag({ image, className: 'h-auto w-auto' }),
-              )
-            : null}
-          {videos.length > 0
-            ? videos?.map((video) =>
-                getVideoTag({ video, className: 'h-auto w-full' }),
-              )
-            : null}
-          {videoLinks.length > 0
-            ? videoLinks?.map((videoLink) =>
-                getVideoLinkTag({ videoLink, className: 'h-auto w-full' }),
-              )
-            : null}
-        </div>
-      </div>
-    )
-  }
+  switch (true) {
+    case mediaLength === 1:
+      return (
+        <>
+          {images.length > 0 && (
+            <div className="w-full md:w-6/12">
+              {getImageTag({
+                image: images?.[0],
+                className: 'h-auto w-full',
+              })}
+            </div>
+          )}
+          {videos.length === 1 && (
+            <div className="w-full md:w-6/12 flex-none">
+              {getVideoTag({ video: videos?.[0], className: 'h-auto w-full' })}
+            </div>
+          )}
+          {videoLinks.length === 1 && (
+            <div className="w-full md:w-6/12 flex-none">
+              {getVideoLinkTag({
+                videoLink: videoLinks?.[0],
+                className: 'h-auto w-full',
+              })}
+            </div>
+          )}
+        </>
+      )
 
-  if (media > 2) {
-    return (
-      <div className="w-full md:w-6/12">
-        <div className="masonry-cols-2 p-4">
-          {images.length > 0
-            ? images?.map((image) => (
-                <div key={image.id} className="mb-4">
-                  {getImageTag({
-                    image,
-                    className: 'h-auto w-full',
-                  })}
-                </div>
-              ))
-            : null}
-          {videos.length > 0
-            ? videos?.map((video) => (
-                <div key={video.id} className="mb-4">
-                  {getVideoTag({ video, className: 'h-auto w-full' })}
-                </div>
-              ))
-            : null}
-          {videoLinks.length > 0
-            ? videoLinks?.map((videoLink) => (
-                <div key={videoLink.id} className="mb-4">
-                  {getVideoLinkTag({ videoLink, className: 'h-auto w-full' })}
-                </div>
-              ))
-            : null}
+    case mediaLength === 2:
+      return (
+        <div className="w-full md:w-6/12">
+          <div className="grid grid-cols-2 gap-4 m-4">
+            {images.length > 0
+              ? images?.map((image) =>
+                  getImageTag({ image, className: 'h-auto w-auto' }),
+                )
+              : null}
+            {videos.length > 0
+              ? videos?.map((video) =>
+                  getVideoTag({ video, className: 'h-auto w-full' }),
+                )
+              : null}
+            {videoLinks.length > 0
+              ? videoLinks?.map((videoLink) =>
+                  getVideoLinkTag({ videoLink, className: 'h-auto w-full' }),
+                )
+              : null}
+          </div>
         </div>
-      </div>
-    )
+      )
+
+    case mediaLength > 2:
+      return (
+        <div className="w-full md:w-6/12">
+          <div className="masonry-cols-2 p-4">
+            {images.length > 0
+              ? images?.map((image) => (
+                  <div key={image.id} className="mb-4">
+                    {getImageTag({
+                      image,
+                      className: 'h-auto w-full',
+                    })}
+                  </div>
+                ))
+              : null}
+            {videos.length > 0
+              ? videos?.map((video) => (
+                  <div key={video.id} className="mb-4">
+                    {getVideoTag({ video, className: 'h-auto w-full' })}
+                  </div>
+                ))
+              : null}
+            {videoLinks.length > 0
+              ? videoLinks?.map((videoLink) => (
+                  <div key={videoLink.id} className="mb-4">
+                    {getVideoLinkTag({ videoLink, className: 'h-auto w-full' })}
+                  </div>
+                ))
+              : null}
+          </div>
+        </div>
+      )
+
+    default:
+      return null
   }
-  return null
 }
 
 // PROPTYPES

--- a/src/components/Story/StoryPresentation.js
+++ b/src/components/Story/StoryPresentation.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import AudioNative from 'components/AudioNative'
 import LazyLoader from 'components/LazyLoader'
 import WysiwygBlock from 'components/WysiwygBlock'
-import { IMAGE, VIDEO, MEDIUM, ORIGINAL } from 'common/constants'
+import { IMAGE, VIDEO, VIDEO_LINK, MEDIUM, ORIGINAL } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 
 function StoryPresentation({ entry }) {
@@ -79,6 +79,36 @@ function StoryPresentation({ entry }) {
           </div>
         </div>
       )}
+      {/* Cover with linked video */}
+      {entry?.coverVisual?.type === VIDEO_LINK && (
+        <div className={headerStyling}>
+          <div className="flex justify-center items-center">
+            <div className="flex w-full max-h-screen">
+              <div className="relative pb-[56.25%] w-full h-0">
+                <iframe
+                  className="absolute t-0 l-0 w-full h-full"
+                  src={entry?.coverVisual?.entry?.embedLink}
+                  title="video"
+                  allowFullScreen
+                >
+                  Your browser does not support the iframe tag.
+                </iframe>
+              </div>
+            </div>
+            <div className="p-6 space-y-4 max-w-lg">
+              <h1 className="font-medium text-2xl md:text-3xl lg:text-4xl xl:text-6xl text-fv-charcoal">
+                {entry?.title}
+              </h1>
+              <h2 className="text-fv-charcoal-light text-lg md:text-xl lg:text-2xl xl:text-3xl">
+                {entry?.titleTranslation}
+              </h2>
+              <div className="text-fv-charcoal-light">
+                {entry?.author?.length > 0 ? ` by ${entry.author}` : ''}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
       {/* Cover no media */}
       {!entry?.coverVisual?.type && (
         <div className={headerStyling}>
@@ -110,6 +140,7 @@ function StoryPresentation({ entry }) {
                 getMedia({
                   images: entry?.relatedImages,
                   videos: entry?.relatedVideos,
+                  videoLinks: entry?.relatedVideoLinks,
                 })}
               <div className="w-full md:w-6/12 flex flex-col grow shrink">
                 <div
@@ -157,6 +188,7 @@ function StoryPresentation({ entry }) {
                   {getMedia({
                     images: page?.relatedImages,
                     videos: page?.relatedVideos,
+                    videoLinks: page?.relatedVideoLinks,
                   })}
                   <div className="w-full md:w-6/12 flex flex-col grow shrink">
                     <div
@@ -239,8 +271,8 @@ function StoryPresentation({ entry }) {
   )
 }
 
-const getMedia = ({ images = [], videos = [] }) => {
-  const media = images.length + videos.length
+const getMedia = ({ images = [], videos = [], videoLinks = [] }) => {
+  const media = images.length + videos.length + videoLinks.length
 
   const getImageTag = ({ image, className }) => (
     <img
@@ -269,6 +301,21 @@ const getMedia = ({ images = [], videos = [] }) => {
     </video>
   )
 
+  const getVideoLinkTag = ({ videoLink, className }) => (
+    <div className={className}>
+      <div className="rounded-lg relative pb-[56.25%] h-0">
+        <iframe
+          className="rounded-lg absolute t-0 l-0 w-full h-full"
+          src={videoLink?.embedLink}
+          title="video"
+          allowFullScreen
+        >
+          Your browser does not support the iframe tag.
+        </iframe>
+      </div>
+    </div>
+  )
+
   if (images.length === 1 && media === 1) {
     return (
       <div className="w-full md:w-6/12">
@@ -286,6 +333,16 @@ const getMedia = ({ images = [], videos = [] }) => {
       </div>
     )
   }
+  if (videoLinks.length === 1 && media === 1) {
+    return (
+      <div className="w-full md:w-6/12 flex-none">
+        {getVideoLinkTag({
+          videoLink: videoLinks?.[0],
+          className: 'h-auto w-full',
+        })}
+      </div>
+    )
+  }
   if (media === 2) {
     return (
       <div className="w-full md:w-6/12">
@@ -298,6 +355,11 @@ const getMedia = ({ images = [], videos = [] }) => {
           {videos.length > 0
             ? videos?.map((video) =>
                 getVideoTag({ video, className: 'h-auto w-full' }),
+              )
+            : null}
+          {videoLinks.length > 0
+            ? videoLinks?.map((videoLink) =>
+                getVideoLinkTag({ videoLink, className: 'h-auto w-full' }),
               )
             : null}
         </div>
@@ -323,6 +385,13 @@ const getMedia = ({ images = [], videos = [] }) => {
             ? videos?.map((video) => (
                 <div key={video.id} className="mb-4">
                   {getVideoTag({ video, className: 'h-auto w-full' })}
+                </div>
+              ))
+            : null}
+          {videoLinks.length > 0
+            ? videoLinks?.map((videoLink) => (
+                <div key={videoLink.id} className="mb-4">
+                  {getVideoLinkTag({ videoLink, className: 'h-auto w-full' })}
                 </div>
               ))
             : null}

--- a/src/components/Story/StoryPresentationDrawer.js
+++ b/src/components/Story/StoryPresentationDrawer.js
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom'
 // FPCC
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import WysiwygBlock from 'components/WysiwygBlock'
-import { IMAGE, VIDEO } from 'common/constants'
+import { IMAGE, VIDEO, VIDEO_LINK } from 'common/constants'
 
 function StoryPresentationDrawer({ entry, sitename }) {
   return (
@@ -52,6 +52,18 @@ function StoryPresentationDrawer({ entry, sitename }) {
           >
             Your browser does not support the video tag.
           </video>
+        </div>
+      )}
+      {entry.coverVisual?.type === VIDEO_LINK && (
+        <div className="my-2 md:my-6 mx-auto px-4 relative pb-[56.25%] h-0">
+          <iframe
+            className="pr-8 absolute t-0 l-0 w-full h-full mx-auto"
+            src={entry?.coverVisual?.entry?.embedLink}
+            title="video"
+            allowFullScreen
+          >
+            Your browser does not support the iframe tag.
+          </iframe>
         </div>
       )}
 

--- a/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
+++ b/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import * as yup from 'yup'
 
@@ -11,6 +11,10 @@ import StoryCrudStepWrapper from 'components/StoryCrud/StoryCrudStepWrapper'
 import { EditorState } from 'draft-js'
 
 function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
+  const [currentLinks, setCurrentLinks] = useState(
+    dataToEdit?.relatedVideoLinks,
+  )
+
   const validator = yup.object().shape({
     title: definitions
       .paragraph({ charCount: 120 })
@@ -22,6 +26,7 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
     relatedAudio: definitions.idArray(),
     relatedImages: definitions.idArray(),
     relatedVideos: definitions.idArray(),
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     acknowledgments: yup.array().of(yup.string()),
   })
 
@@ -32,6 +37,7 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
     titleTranslation: '',
     author: '',
     relatedVideos: [],
+    relatedVideoLinks: [],
     relatedImages: [],
     // Introduction
     intro: EditorState.createEmpty(),
@@ -46,12 +52,20 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
 
   // pageOrder
 
-  const { control, errors, handleSubmit, isValid, register, reset, trigger } =
-    useEditForm({
-      defaultValues,
-      validator,
-      dataToEdit,
-    })
+  const {
+    control,
+    errors,
+    handleSubmit,
+    isValid,
+    register,
+    reset,
+    setValue,
+    trigger,
+  } = useEditForm({
+    defaultValues,
+    validator,
+    dataToEdit,
+  })
 
   const stepCallback = () => {
     trigger()
@@ -59,6 +73,10 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
       handleSubmit(submitHandler)()
     }
   }
+
+  useEffect(() => {
+    setValue('relatedVideoLinks', currentLinks)
+  }, [currentLinks])
 
   return (
     <StoryCrudStepWrapper onClickCallback={stepCallback}>
@@ -145,6 +163,9 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
                 control={control}
                 type={VIDEO}
                 maxItems={1}
+                relatedVideoLinks={dataToEdit?.relatedVideoLinks}
+                currentLinks={currentLinks}
+                setCurrentLinks={setCurrentLinks}
               />
               {errors?.relatedVideos && (
                 <div className="text-red-500">

--- a/src/components/StoryCrud/StoryCrudPreview.js
+++ b/src/components/StoryCrud/StoryCrudPreview.js
@@ -53,7 +53,7 @@ function StoryCrudPreview({ storyData }) {
     </Link>
   )
 
-  const relatedVisualMediaThumbnails = ({ images, videos }) => {
+  const relatedVisualMediaThumbnails = ({ images, videos, videoLinks }) => {
     if (!images?.length > 0 && !videos?.length > 0) {
       return null
     }
@@ -73,6 +73,13 @@ function StoryCrudPreview({ storyData }) {
             <MediaThumbnail.Video
               key={videoId}
               id={videoId}
+              containerStyles="w-40 h-40 mr-2"
+            />
+          ))}
+        {videoLinks?.length > 0 &&
+          videoLinks?.map((videoLink) => (
+            <MediaThumbnail.VideoLink
+              link={videoLink}
               containerStyles="w-40 h-40 mr-2"
             />
           ))}
@@ -144,6 +151,7 @@ function StoryCrudPreview({ storyData }) {
               {relatedVisualMediaThumbnails({
                 images: storyData?.relatedImages,
                 videos: storyData?.relatedVideos,
+                videoLinks: storyData?.relatedVideoLinks,
               })}
             </div>
           </div>
@@ -162,6 +170,7 @@ function StoryCrudPreview({ storyData }) {
               {relatedVisualMediaThumbnails({
                 images: currentPage?.relatedImages,
                 videos: currentPage?.relatedVideos,
+                videoLinks: currentPage?.relatedVideoLinks,
               })}
             </div>
             <div className="col-span-1 space-y-4">

--- a/src/components/StoryCrud/StoryCrudPreview.js
+++ b/src/components/StoryCrud/StoryCrudPreview.js
@@ -54,7 +54,7 @@ function StoryCrudPreview({ storyData }) {
   )
 
   const relatedVisualMediaThumbnails = ({ images, videos, videoLinks }) => {
-    if (!images?.length > 0 && !videos?.length > 0) {
+    if (!images?.length > 0 && !videos?.length > 0 && !videoLinks?.length > 0) {
       return null
     }
     return (
@@ -79,6 +79,7 @@ function StoryCrudPreview({ storyData }) {
         {videoLinks?.length > 0 &&
           videoLinks?.map((videoLink) => (
             <MediaThumbnail.VideoLink
+              key={videoLink?.id}
               link={videoLink}
               containerStyles="w-40 h-40 mr-2"
             />

--- a/src/components/StoryPagesCrud/StoryPageForm.js
+++ b/src/components/StoryPagesCrud/StoryPageForm.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import * as yup from 'yup'
 import { EditorState } from 'draft-js'
@@ -18,6 +18,10 @@ function StoryPageForm({
   pageNumber,
   submitHandler,
 }) {
+  const [currentLinks, setCurrentLinks] = useState(
+    dataToEdit?.relatedVideoLinks,
+  )
+
   const validator = yup.object().shape({
     text: definitions.wysiwyg({ charCount: 5000 }),
     textTranslation: definitions.wysiwyg({ charCount: 5000 }),
@@ -25,6 +29,7 @@ function StoryPageForm({
     relatedAudio: definitions.idArray(),
     relatedImages: definitions.idArray(),
     relatedVideos: definitions.idArray(),
+    relatedVideoLinks: definitions.relatedVideoUrlsArray(),
   })
 
   const defaultValues = {
@@ -35,14 +40,20 @@ function StoryPageForm({
     relatedAudio: [],
     relatedImages: [],
     relatedVideos: [],
+    relatedVideoLinks: [],
     ordering: nextPageOrderNumber,
   }
 
-  const { control, errors, handleSubmit, register, reset } = useEditForm({
-    defaultValues,
-    validator,
-    dataToEdit,
-  })
+  const { control, errors, handleSubmit, register, reset, setValue } =
+    useEditForm({
+      defaultValues,
+      validator,
+      dataToEdit,
+    })
+
+  useEffect(() => {
+    setValue('relatedVideoLinks', currentLinks)
+  }, [currentLinks])
 
   return (
     <div id="StoryPageForm" className="p-4 bg-white text-fv-charcoal">
@@ -103,6 +114,9 @@ function StoryPageForm({
             control={control}
             type={VIDEO}
             maxItems={1}
+            relatedVideoLinks={dataToEdit?.relatedVideoLinks}
+            currentLinks={currentLinks}
+            setCurrentLinks={setCurrentLinks}
           />
           {errors?.relatedVideos && (
             <div className="text-red-500">{errors?.relatedVideos?.message}</div>

--- a/src/components/StoryPagesCrud/StoryPagesCrudPreview.js
+++ b/src/components/StoryPagesCrud/StoryPagesCrudPreview.js
@@ -17,6 +17,9 @@ function StoryPagesCrudPreview({ page, pageNumber }) {
     if (page?.relatedVideos?.length > 0) {
       return <MediaThumbnail.Video id={page?.relatedVideos?.[0]} />
     }
+    if (page?.relatedVideoLinks?.length > 0) {
+      return <MediaThumbnail.VideoLink link={page?.relatedVideoLinks?.[0]} />
+    }
     return ''
   }
 


### PR DESCRIPTION
### Description of Changes
This PR adds related video links support to the dashboard media browser/forms ([FW-5368](https://firstvoices.atlassian.net/browse/FW-5368)) and the places where uploaded videos can be viewed ([FW-5380](https://firstvoices.atlassian.net/browse/FW-5380)).

Related video links can be added to dictionary entries, songs, stories, and alphabet characters.

The [lodash.get](https://www.npmjs.com/package/lodash.get) package has been added as a dependency to assist with duplicate link validation in the dashboard forms.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [x] Pull the branch and test locally

### Additional Notes

N/A


[FW-5368]: https://firstvoices.atlassian.net/browse/FW-5368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FW-5380]: https://firstvoices.atlassian.net/browse/FW-5380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ