### PR TITLE
FW-5443 Sort wordsy keyboard alphabet order alphabetically

### DIFF
--- a/src/components/Game/Wordsy/Utils/helpers.js
+++ b/src/components/Game/Wordsy/Utils/helpers.js
@@ -1,5 +1,7 @@
 export const getOrthographyPattern = (orthography) => {
-  const SORTED_ORTHOGRAPHY = orthography?.sort((a, b) => b.length - a.length)
+  const SORTED_ORTHOGRAPHY = orthography
+    ?.slice()
+    .sort((a, b) => b.length - a.length)
 
   return new RegExp(`(${SORTED_ORTHOGRAPHY?.join('|')})`, 'g')
 }


### PR DESCRIPTION
### Description of Changes
This PR fixes the wordsy keyboard alphabet ordering, keeping the buttons sorted alphabetically instead of by length.

### Checklist

- ~README / documentation has been updated if needed~
- [x] PR title / commit messages contain Jira ticket number if applicable
- ~Tests have been updated / created if applicable~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
