### PR TITLE
FW-5521 Fix sharebutton and qrcodebutton links

### DIFF
--- a/src/components/Actions/ShareButton.js
+++ b/src/components/Actions/ShareButton.js
@@ -9,7 +9,13 @@ import ShareLinks from 'components/ShareLinks'
 import Modal from 'components/Modal'
 import { MEMBERS, TEAM } from 'common/constants'
 
-function ShareButton({ entry, siteVisibility, iconStyling, withLabels }) {
+function ShareButton({
+  entry,
+  sitename,
+  siteVisibility,
+  iconStyling,
+  withLabels,
+}) {
   const [shareModalOpen, setShareModalOpen] = useState(false)
   return (
     <Menu.Item>
@@ -51,9 +57,9 @@ function ShareButton({ entry, siteVisibility, iconStyling, withLabels }) {
                     className="my-2 mx-1 h-9 w-9 inline-flex items-center align-center justify-center rounded text-white bg-secondary"
                     href={`mailto:?subject=${
                       entry?.title
-                    }&body=${window.location.origin.toString()}/${
-                      entry?.sitename
-                    }/${makePlural(entry?.type)}/${entry?.id}`}
+                    }&body=${window.location.origin.toString()}/${sitename}/${makePlural(
+                      entry?.type,
+                    )}/${entry?.id}`}
                   >
                     {getIcon('Mail', 'fill-current h-7 w-7')}
                   </a>
@@ -64,9 +70,9 @@ function ShareButton({ entry, siteVisibility, iconStyling, withLabels }) {
                     Share <em>{entry?.title}</em> on:
                   </h3>
                   <ShareLinks.Presentation
-                    url={`${window.location.origin.toString()}/${
-                      entry?.sitename
-                    }/${makePlural(entry?.type)}/${entry?.id}`}
+                    url={`${window.location.origin.toString()}/${sitename}/${makePlural(
+                      entry?.type,
+                    )}/${entry?.id}`}
                     title={entry?.title}
                     modalCloseHandler={() => setShareModalOpen(false)}
                   />
@@ -91,6 +97,7 @@ function ShareButton({ entry, siteVisibility, iconStyling, withLabels }) {
 const { bool, object, string } = PropTypes
 ShareButton.propTypes = {
   entry: object,
+  sitename: string,
   iconStyling: string,
   withLabels: bool,
   siteVisibility: string,

--- a/src/components/ActionsMenu/ActionsMenuPresentation.js
+++ b/src/components/ActionsMenu/ActionsMenuPresentation.js
@@ -9,6 +9,7 @@ import { makePlural } from 'common/utils/urlHelpers'
 
 function ActionsMenuPresentation({
   entry,
+  sitename,
   siteVisibility,
   actions,
   moreActions,
@@ -64,6 +65,7 @@ function ActionsMenuPresentation({
                       <ShareButton
                         withLabels
                         entry={entry}
+                        sitename={sitename}
                         iconStyling={iconStyling}
                         siteVisibility={siteVisibility}
                       />
@@ -73,9 +75,9 @@ function ActionsMenuPresentation({
                         withLabels
                         iconStyling={iconStyling}
                         entry={entry}
-                        url={`${window.location.origin.toString()}/${
-                          entry?.sitename
-                        }/${makePlural(entry?.type)}/${entry?.id}`}
+                        url={`${window.location.origin.toString()}/${sitename}/${makePlural(
+                          entry?.type,
+                        )}/${entry?.id}`}
                       />
                     )}
                   </div>
@@ -92,6 +94,7 @@ function ActionsMenuPresentation({
 const { array, bool, object, string } = PropTypes
 ActionsMenuPresentation.propTypes = {
   entry: object,
+  sitename: string,
   siteVisibility: string,
   actions: array,
   moreActions: array,

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -53,6 +53,7 @@ function DictionaryDetailPresentation({
               <div className="mt-4 md:mt-1 md:ml-4">
                 <ActionsMenu.Presentation
                   entry={entry}
+                  sitename={sitename}
                   actions={actions}
                   moreActions={moreActions}
                   iconStyling="w-6 h-6"

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -40,6 +40,7 @@ function DictionaryDetailPresentationDrawer({
             <div className="ml-5">
               <ActionsMenu.Presentation
                 entry={entry}
+                sitename={sitename}
                 actions={actions}
                 moreActions={moreActions}
                 withLabels

--- a/src/components/DictionaryGridTile/DictionaryGridTilePresentation.js
+++ b/src/components/DictionaryGridTile/DictionaryGridTilePresentation.js
@@ -33,6 +33,7 @@ function DictionaryGridTilePresentation({ actions, moreActions, entry }) {
             </Link>
             <ActionsMenu.Presentation
               entry={entry}
+              sitename={entry?.sitename}
               actions={actions}
               moreActions={moreActions}
               iconStyling="w-8 h-8"

--- a/src/components/DictionaryList/DictionaryListPresentation.js
+++ b/src/components/DictionaryList/DictionaryListPresentation.js
@@ -181,6 +181,7 @@ function DictionaryListPresentation({
                           >
                             <ActionsMenu.Presentation
                               entry={entry}
+                              sitename={entry?.sitename}
                               siteVisibility={entry?.siteVisibility}
                               actions={actions}
                               moreActions={moreActions}

--- a/src/components/Immersion/ImmersionPresentationList.js
+++ b/src/components/Immersion/ImmersionPresentationList.js
@@ -65,6 +65,7 @@ function ImmersionPresentationList({ actions, isLoading, items }) {
                           <td className="text-right px-6" aria-label="list">
                             <ActionsMenu.Presentation
                               entry={dictionaryEntry?.[0]}
+                              sitename={dictionaryEntry?.[0]?.sitename}
                               actions={actions}
                               withConfirmation
                               withTooltip


### PR DESCRIPTION
### Description of Changes

- Adds a `sitename` prop to ShareButton and ActionsMenuPresentation allowing the DictionaryDetail components to pass the site name for correct QR code and share link generation.
- Passes the sitename prop to ActionsMenuPresentation in all uses for consistency

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
