### PR TITLE
FW-5472, FW-5482 immersion toggle mobile and immersion persist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "howler": "^2.2.3",
         "html-webpack-plugin": "^5.6.0",
         "i18next": "^23.7.11",
+        "i18next-browser-languagedetector": "^7.2.0",
         "ky": "^1.2.0",
         "oidc-client-ts": "^2.2.4",
         "postcss": "^8.4.23",
@@ -9261,6 +9262,14 @@
           "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
         }
       ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.0.tgz",
+      "integrity": "sha512-U00DbDtFIYD3wkWsr2aVGfXGAj2TgnELzOX9qv8bT0aJtvPV9CRO77h+vgmHFBMe7LAxdwvT/7VkCWGya6L3tA==",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "howler": "^2.2.3",
     "html-webpack-plugin": "^5.6.0",
     "i18next": "^23.7.11",
+    "i18next-browser-languagedetector": "^7.2.0",
     "ky": "^1.2.0",
     "oidc-client-ts": "^2.2.4",
     "postcss": "^8.4.23",

--- a/src/common/dataHooks/useImmersionLabels.js
+++ b/src/common/dataHooks/useImmersionLabels.js
@@ -25,7 +25,7 @@ export function useImmersionMap() {
   const { sitename } = useParams()
 
   const response = useQuery(
-    [IMMERSION_LABELS, sitename],
+    [IMMERSION_LABELS, sitename, 'mapped'],
     () => api.immersionLabels.getMapped({ sitename }),
     { enabled: !!sitename },
   )

--- a/src/components/ImmersionToggle/ImmersionTogglePresentation.js
+++ b/src/components/ImmersionToggle/ImmersionTogglePresentation.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+
+// FPCC
+import Toggle from 'components/Toggle'
+import getIcon from 'common/utils/getIcon'
+import { IMMERSION } from 'common/constants'
+
+function ImmersionTogglePresentation({ site }) {
+  const { i18n } = useTranslation()
+
+  const hasImmersion =
+    typeof site?.checkForEnabledFeature === 'function'
+      ? site?.checkForEnabledFeature(IMMERSION)
+      : false
+
+  const changeLanguage = (setToLanguage) => {
+    if (setToLanguage) {
+      i18n.changeLanguage('language')
+    } else {
+      i18n.changeLanguage('en')
+    }
+  }
+
+  return hasImmersion ? (
+    <div
+      data-testid="ImmersionTogglePresentation"
+      className="w-full flex justify-between items-center"
+    >
+      <Toggle
+        accentColor="secondary"
+        toggled={i18n.language === 'language'}
+        toggleCallback={() => changeLanguage(i18n.language !== 'language')}
+        label="Immersion Mode"
+      />
+      <Link
+        to={`/${site?.sitename}/immersion`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {getIcon('Question', 'fill-current text-secondary ml-3 h-6 w-auto')}
+      </Link>
+    </div>
+  ) : null
+}
+// PROPTYPES
+const { object } = PropTypes
+ImmersionTogglePresentation.propTypes = {
+  site: object,
+}
+
+export default ImmersionTogglePresentation

--- a/src/components/ImmersionToggle/index.js
+++ b/src/components/ImmersionToggle/index.js
@@ -1,0 +1,3 @@
+import ImmersionToggle from 'components/ImmersionToggle/ImmersionTogglePresentation'
+
+export default ImmersionToggle

--- a/src/components/NavBar/NavBarPresentationMobile.js
+++ b/src/components/NavBar/NavBarPresentationMobile.js
@@ -2,13 +2,15 @@ import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import { Transition } from '@headlessui/react'
+import { useTranslation } from 'react-i18next'
 
 // FPCC
 import getIcon from 'common/utils/getIcon'
 import { useUserStore } from 'context/UserContext'
 import useLoginLogout from 'common/hooks/useLoginLogout'
 import { isMember } from 'common/utils/membershipHelpers'
-import { useTranslation } from 'react-i18next'
+import { IMMERSION } from 'common/constants'
+import ImmersionToggle from 'components/ImmersionToggle'
 
 function NavBarPresentationMobile({ site }) {
   const { user } = useUserStore()
@@ -17,6 +19,11 @@ function NavBarPresentationMobile({ site }) {
   const isGuest = user.isAnonymous
   const { login, logout } = useLoginLogout()
   const [t] = useTranslation()
+
+  const hasImmersion =
+    typeof site?.checkForEnabledFeature === 'function'
+      ? site?.checkForEnabledFeature(IMMERSION)
+      : false
 
   const onMenuClick = (event, menuObject) => {
     event.stopPropagation()
@@ -27,6 +34,9 @@ function NavBarPresentationMobile({ site }) {
 
   const menuData = site?.menu || {}
   const member = isMember({ user, sitename: site.sitename })
+  const buttonStyling = 'w-full px-1 py-2 flex items-center rounded'
+  const labelStyling = 'truncate ml-3 font-medium'
+  const iconStyling = 'fill-current h-12 w-8 flex-none'
 
   function generateMenuItem(menuItem) {
     const hasItems = menuItem?.itemsData?.length > 0
@@ -39,10 +49,10 @@ function NavBarPresentationMobile({ site }) {
             onClick={(e) => {
               onMenuClick(e, menuItem)
             }}
-            className="w-full my-2 p-1 flex items-center rounded"
+            className={buttonStyling}
           >
-            {getIcon(menuItem.title, 'fill-current h-12 w-8')}
-            <span className="truncate ml-3 font-medium">
+            {getIcon(menuItem.title, iconStyling)}
+            <span className={labelStyling}>
               {menuItem.transKey ? t(menuItem.transKey) : menuItem.title}
             </span>
             {getIcon('ChevronRight', 'absolute right-3 fill-current w-10')}
@@ -50,11 +60,11 @@ function NavBarPresentationMobile({ site }) {
         ) : (
           <Link
             data-testid={`${menuItem.title}-link`}
-            className="w-full my-2 p-1 flex items-center rounded"
+            className={buttonStyling}
             to={`/${site.sitename + menuItem.href}`}
           >
-            {getIcon(menuItem.title, 'fill-current h-12 w-8')}{' '}
-            <span className="truncate ml-3 font-medium">
+            {getIcon(menuItem.title, iconStyling)}{' '}
+            <span className={labelStyling}>
               {menuItem.transKey ? t(menuItem.transKey) : menuItem.title}
             </span>
           </Link>
@@ -73,7 +83,7 @@ function NavBarPresentationMobile({ site }) {
       >
         <ul className="divide-y-2 divide-gray-200 bg-white p-2 overflow-y-auto">
           {!isGuest && (
-            <li className="w-full my-1 p-1 flex items-center rounded ml-3 font-medium">
+            <li className="w-full p-1 flex items-center rounded ml-3 font-medium">
               Welcome
               {user?.displayName ? `, ${user?.displayName}!` : '!'}
             </li>
@@ -83,17 +93,18 @@ function NavBarPresentationMobile({ site }) {
           {menuData?.resources && generateMenuItem(menuData?.resources)}
           {menuData?.about && generateMenuItem(menuData?.about)}
           {menuData?.kids && generateMenuItem(menuData?.kids)}
+
           {isGuest ? (
             <li>
               <button
                 data-testid="login-button"
-                className="w-full my-3 p-1 flex items-center rounded"
+                className={buttonStyling}
                 type="button"
                 onClick={login}
                 onKeyDown={login}
               >
-                {getIcon('Login', 'fill-current h-12 w-8')}
-                <span className="ml-3 font-medium">Sign in / Register</span>
+                {getIcon('Login', iconStyling)}
+                <span className={labelStyling}>Sign in / Register</span>
               </button>
             </li>
           ) : (
@@ -102,27 +113,36 @@ function NavBarPresentationMobile({ site }) {
                 <li>
                   <Link
                     data-testid="join-link"
-                    className="w-full my-3 p-1 flex items-center rounded"
+                    className={buttonStyling}
                     to={`/${site?.sitename}/join`}
                   >
-                    {getIcon('Members', 'fill-current h-12 w-8')}{' '}
-                    <span className="ml-3 font-medium">{`Join ${site?.title}`}</span>
+                    {getIcon('Members', iconStyling)}{' '}
+                    <span
+                      className={labelStyling}
+                    >{`Join ${site?.title}`}</span>
                   </Link>
                 </li>
               )}
-              <li key="SignOut_id">
+              <li>
                 <button
                   data-testid="logout-button"
-                  className="w-full my-3 p-1 flex items-center rounded"
+                  className={buttonStyling}
                   type="button"
                   onClick={logout}
                   onKeyDown={logout}
                 >
-                  {getIcon('LogOut', 'fill-current h-12 w-8')}
-                  <span className="ml-3 font-medium">Sign Out</span>
+                  {getIcon('LogOut', iconStyling)}
+                  <span className={labelStyling}>Sign Out</span>
                 </button>
               </li>
             </>
+          )}
+          {hasImmersion && (
+            <li>
+              <div className={buttonStyling}>
+                <ImmersionToggle site={site} />
+              </div>
+            </li>
           )}
         </ul>
       </Transition>
@@ -146,10 +166,10 @@ function NavBarPresentationMobile({ site }) {
                 type="button"
                 onClick={() => setIsSubMenuOpen(false)}
                 onKeyDown={() => setIsSubMenuOpen(false)}
-                className="w-full m-3 p-1 flex items-center focus:outline-none"
+                className={buttonStyling}
               >
-                {getIcon('ChevronLeft', 'fill-current h-12 w-8')}
-                <span className="ml-3 font-medium">Back</span>
+                {getIcon('ChevronLeft', iconStyling)}
+                <span className={labelStyling}>Back</span>
               </button>
             </li>
           </ul>

--- a/src/components/NavBar/NavBarPresentationMobile.js
+++ b/src/components/NavBar/NavBarPresentationMobile.js
@@ -83,7 +83,7 @@ function NavBarPresentationMobile({ site }) {
       >
         <ul className="divide-y-2 divide-gray-200 bg-white p-2 overflow-y-auto">
           {!isGuest && (
-            <li className="w-full p-1 flex items-center rounded ml-3 font-medium">
+            <li className={buttonStyling}>
               Welcome
               {user?.displayName ? `, ${user?.displayName}!` : '!'}
             </li>
@@ -139,7 +139,7 @@ function NavBarPresentationMobile({ site }) {
           )}
           {hasImmersion && (
             <li>
-              <div className={buttonStyling}>
+              <div className={`${buttonStyling} px-2 my-2`}>
                 <ImmersionToggle site={site} />
               </div>
             </li>

--- a/src/components/UserMenu/UserMenuPresentation.js
+++ b/src/components/UserMenu/UserMenuPresentation.js
@@ -1,29 +1,17 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
-import { useTranslation } from 'react-i18next'
 import { Menu, Transition } from '@headlessui/react'
 
 // FPCC
-import Toggle from 'components/Toggle'
-import getIcon from 'common/utils/getIcon'
+import ImmersionToggle from 'components/ImmersionToggle'
 import { IMMERSION } from 'common/constants'
 
 function UserMenuPresentation({ currentUser, site, login, logout }) {
-  const { i18n } = useTranslation()
-
   const hasImmersion =
     typeof site?.checkForEnabledFeature === 'function'
       ? site?.checkForEnabledFeature(IMMERSION)
       : false
-
-  const changeLanguage = (setToLanguage) => {
-    if (setToLanguage) {
-      i18n.changeLanguage('language')
-    } else {
-      i18n.changeLanguage('en')
-    }
-  }
 
   const menuItemActiveClass = 'bg-gray-200 text-black rounded ring-black'
   const menuItemInactiveClass = 'text-fv-charcoal'
@@ -78,31 +66,12 @@ function UserMenuPresentation({ currentUser, site, login, logout }) {
             {hasImmersion && (
               <Menu.Item className="w-full flex">
                 {({ active }) => (
-                  <div className="w-full flex justify-between items-center">
-                    <div
-                      className={`${
-                        active ? menuItemActiveClass : menuItemInactiveClass
-                      } ${menuItemBaseClass} flex`}
-                    >
-                      <Toggle
-                        accentColor="secondary"
-                        toggled={i18n.language === 'language'}
-                        toggleCallback={() =>
-                          changeLanguage(i18n.language !== 'language')
-                        }
-                        label="Immersion Mode"
-                      />
-                      <Link
-                        to={`/${site?.sitename}/immersion`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {getIcon(
-                          'Question',
-                          'fill-current text-secondary ml-3 h-6 w-auto',
-                        )}
-                      </Link>
-                    </div>
+                  <div
+                    className={`${
+                      active ? menuItemActiveClass : menuItemInactiveClass
+                    } ${menuItemBaseClass} flex`}
+                  >
+                    <ImmersionToggle site={site} />
                   </div>
                 )}
               </Menu.Item>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,5 +1,6 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
 
 // FPCC
 import en from 'assets/locale/en'
@@ -7,12 +8,15 @@ import en from 'assets/locale/en'
 i18n
   // pass the i18n instance to react-i18next.
   .use(initReactI18next)
+  // detect user language
+  // learn more: https://github.com/i18next/i18next-browser-languageDetector
+  .use(LanguageDetector)
   // init i18next - for all options read: https://www.i18next.com/overview/configuration-options
   .init({
+    fallbackLng: 'en',
     resources: {
       en,
     },
-    fallbackLng: 'en',
     debug: false,
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default


### PR DESCRIPTION
### Description of Changes

- Added i18next-browser-languagedetector to handle persistence of language selection
- fixed bug where immersion labels would carry to sites that don't have any labels
- fixed bug where immersion mode would stay on even if switched to a site without the immersion feature enabled
- Moved the immersion toggle into a reusable component
- Added immersion toggle to mobile menu and adjusted styling

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
