### PR TITLE
FW-5552 Allow short youtube links in FE validator

### DIFF
--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -62,7 +62,7 @@ const relatedVideoLinksUrls = yup
   .string()
   .trim()
   .matches(
-    /(^(https?:\/\/)?|^)(?:www.)?(?:((vimeo)\.com\/(.+))|((youtube)\.com\/watch\?v=(.+)))/,
+    /(^(https?:\/\/)?|^)(?:www\.)?(?:(vimeo\.com\/([a-zA-Z0-9_-]+))|(youtu\.be\/([a-zA-Z0-9_-]+))|(youtube\.com\/watch\?v=([a-zA-Z0-9_-]+)))/,
     {
       message: 'Only YouTube and Vimeo links are currently supported',
       excludeEmptyString: true,


### PR DESCRIPTION
### Description of Changes
Updates the validation regex to include short youtube links

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes
I could also update the placeholder in the video link input to: 

"Example links: https://www.youtube.com/watch?v=A1B2C3D4E5F, https://youtu.be/A1B2C3D4E5F or https://vimeo.com/123456789"

If the team would like, but I wasn't sure if that would be unnecessary/confusing. 