### PR TITLE
FW-5543 Handle empty wysiwygState string

### DIFF
--- a/src/common/utils/wysiwygStateHelpers.js
+++ b/src/common/utils/wysiwygStateHelpers.js
@@ -32,6 +32,7 @@ function wysiwygStateHelpers() {
 
   // Converts Draft-js ContentState into raw JSON format
   const getJsonFromWysiwygState = (wysiwygState) => {
+    if (!wysiwygState) return ''
     const content = wysiwygState?.getCurrentContent()
     if (content?.hasText()) {
       return JSON.stringify(convertToRaw(content))


### PR DESCRIPTION
### Description of Changes
- This PR fixes a bug in https://firstvoices.atlassian.net/browse/FW-5543 which prevented the widget form from being saved if both the "Address" and "Social media links" fields were empty.
- This is done by returning '' if a wysiwygState string is falsy in the `getJsonFromWysiwygState` constant

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
