### PR TITLE
Fw 5555 alphabet widget fix and search results count fix

### DIFF
--- a/src/components/AdvancedSearchOptions/AdvancedSearchOptionsPresentation.js
+++ b/src/components/AdvancedSearchOptions/AdvancedSearchOptionsPresentation.js
@@ -21,7 +21,12 @@ import {
 } from 'common/constants'
 
 function AdvancedSearchOptionsPresentation({ items }) {
-  const results = items?.pages[0]?.count
+  const count = items?.pages[0]?.count
+  let countStr = count
+  if (count >= 10000) {
+    countStr = '10000+'
+  }
+
   return (
     <div
       data-testid="AdvancedSearchOptionsPresentation"
@@ -46,7 +51,7 @@ function AdvancedSearchOptionsPresentation({ items }) {
                 menuAlignment="left"
               />
               <p className="text-sm text-fv-charcoal-light">
-                Results : {results}{' '}
+                Results : {countStr}{' '}
               </p>
             </div>
 

--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -20,8 +20,15 @@ function AlphabetPresentationSelected({
   generalNote,
   videoIsOpen,
   alphabetLink,
+  entriesCount,
 }) {
   const { sitename } = useParams()
+  let entriesToDisplay = relatedDictionaryEntries // To not make changes to a param variable if we get entriesCount
+
+  if (entriesCount) {
+    entriesToDisplay = entriesToDisplay?.splice(0, entriesCount)
+  }
+
   return (
     <>
       <h1
@@ -69,12 +76,12 @@ function AlphabetPresentationSelected({
           />
         </div>
       )}
-      {relatedDictionaryEntries?.length > 0 && (
+      {entriesToDisplay?.length > 0 && (
         <div className="mx-auto my-5 w-4/5">
           <h2 className="sm:text-2xl font-medium text-xl text-center text-primary p-3">
             Example words
           </h2>
-          {relatedDictionaryEntries.map((word, index) => {
+          {entriesToDisplay?.map((word, index) => {
             const zebraStripe = index % 2 === 0 ? 'bg-gray-100' : ''
             return (
               <div
@@ -209,7 +216,7 @@ function AlphabetPresentationSelected({
 }
 
 // PROPTYPES
-const { array, bool, func, object, string } = PropTypes
+const { array, bool, func, number, object, string } = PropTypes
 
 AlphabetPresentationSelected.propTypes = {
   title: string,
@@ -223,6 +230,7 @@ AlphabetPresentationSelected.propTypes = {
   videoIsOpen: bool,
   kids: bool,
   alphabetLink: bool,
+  entriesCount: number,
 }
 
 AlphabetPresentationSelected.defaultProps = {

--- a/src/components/Alphabet/AlphabetPresentationWidget.js
+++ b/src/components/Alphabet/AlphabetPresentationWidget.js
@@ -73,6 +73,7 @@ function AlphabetPresentationWidget({
                 }
                 relatedAudio={selectedData?.relatedAudio}
                 alphabetLink
+                entriesCount={1}
               />
             )}
             {links?.length > 0 && (

--- a/src/components/Dictionary/DictionaryPresentation.js
+++ b/src/components/Dictionary/DictionaryPresentation.js
@@ -31,6 +31,12 @@ function DictionaryPresentation({
     link: 'flex items-center transition duration-500 ease-in-out p-2 grow rounded-lg capitalize cursor-pointer text-lg xl:text-xl text-fv-charcoal',
     icon: 'inline-flex fill-current w-6 xl:w-8 mr-2 xl:mr-5',
   }
+
+  let countStr = count
+  if (count >= 10000) {
+    countStr = '10000+'
+  }
+
   return (
     <>
       <section
@@ -101,7 +107,7 @@ function DictionaryPresentation({
               <li
                 className={`${linkStyle.li} p-2 grow text-lg xl:text-xl text-fv-charcoal`}
               >
-                Results: {count}{' '}
+                Results: {countStr}{' '}
                 {searchType === TYPE_PHRASE ? `phrases` : `words`}
               </li>
             </ul>


### PR DESCRIPTION
### Description of Changes
- Added an `entriesCount` parameter to control number of entries being displayed in AlphabetPresentationSelected component.
- Update the results count in both splashboard and dashboard to display a '+' in case there are more than 10k search results.

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
