### PR TITLE
Only process date if it is not NaN

### DIFF
--- a/src/common/utils/stringHelpers.js
+++ b/src/common/utils/stringHelpers.js
@@ -236,8 +236,10 @@ export const localDateMDYTwords = (dateString) => {
     timeStyle: 'short',
     dateStyle: 'long',
   }
-  // defaults to local time if no timeZone is set in options
-  return new Intl.DateTimeFormat('en-CA', options).format(date)
+  // Only process date if it is not NaN
+  return !Number.isNaN(date)
+    ? new Intl.DateTimeFormat('en-CA', options).format(date) // defaults to local time if no timeZone is set in options
+    : ''
 }
 
 export const localDateMDYT = (dateString) => {
@@ -247,8 +249,10 @@ export const localDateMDYT = (dateString) => {
     dateStyle: 'short',
     hour12: false,
   }
-  // defaults to local time if no timeZone is set in options
-  return new Intl.DateTimeFormat('en-CA', options).format(date)
+  // Only process date if it is not NaN
+  return !Number.isNaN(date)
+    ? new Intl.DateTimeFormat('en-CA', options).format(date) // defaults to local time if no timeZone is set in options
+    : ''
 }
 
 export const safeJsonParse = (str) => {


### PR DESCRIPTION
### Description of Changes

Adds a check for `NaN` `Date` value before processing `Intl.DateTimeFormat`

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
