### PR TITLE
FW-4828 assistants can edit team only dictionary entries

### DIFF
--- a/src/common/RequireAuth.js
+++ b/src/common/RequireAuth.js
@@ -1,28 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { useParams } from 'react-router-dom'
 
 // FPCC
 import { useUserStore } from 'context/UserContext'
+import useAuthCheck from 'common/hooks/useAuthCheck'
 import ErrorHandler from 'components/ErrorHandler'
-import { isAuthorized } from 'common/utils/authHelpers'
 import Loading from 'components/Loading'
 
 function RequireAuth({ children, siteMembership, withMessage }) {
   const { user, isLoading } = useUserStore()
-  const { sitename } = useParams()
-
-  if (user?.isSuperAdmin) {
-    return children
-  }
-
-  const userRoles = user?.roles || {}
-  const userSiteRole = userRoles?.[sitename] || ''
-
-  const authorized = isAuthorized({
-    requiredMembershipRole: siteMembership,
-    userMembershipRole: userSiteRole,
-  })
+  const { checkRoleAuth } = useAuthCheck()
+  const authorized = checkRoleAuth(siteMembership)
 
   const unauthorised = withMessage ? (
     <Loading.Container isLoading={isLoading}>

--- a/src/common/RequireAuth.js
+++ b/src/common/RequireAuth.js
@@ -9,8 +9,8 @@ import Loading from 'components/Loading'
 
 function RequireAuth({ children, siteMembership, withMessage }) {
   const { user, isLoading } = useUserStore()
-  const { checkRoleAuth } = useAuthCheck()
-  const authorized = checkRoleAuth(siteMembership)
+  const { checkIfUserAtLeastRole } = useAuthCheck()
+  const authorized = checkIfUserAtLeastRole(siteMembership)
 
   const unauthorised = withMessage ? (
     <Loading.Container isLoading={isLoading}>

--- a/src/common/hooks/useAuthCheck.js
+++ b/src/common/hooks/useAuthCheck.js
@@ -11,7 +11,7 @@ function useAuthCheck() {
   const userRoles = user?.roles || {}
   const userMembershipRole = userRoles?.[sitename] || ''
 
-  const checkRoleAuth = (requiredMembershipRole) => {
+  const checkIfUserAtLeastRole = (requiredMembershipRole) => {
     if (user?.isSuperAdmin) {
       return true
     }
@@ -21,7 +21,7 @@ function useAuthCheck() {
     })
   }
 
-  const checkRoleEditAuth = ({ objectToEdit }) =>
+  const checkIfUserCanEdit = (objectToEdit) =>
     userCanEdit({
       type: objectToEdit?.type,
       visibility: objectToEdit?.visibility,
@@ -29,8 +29,8 @@ function useAuthCheck() {
     })
 
   return {
-    checkRoleAuth,
-    checkRoleEditAuth,
+    checkIfUserAtLeastRole,
+    checkIfUserCanEdit,
   }
 }
 

--- a/src/common/hooks/useAuthCheck.js
+++ b/src/common/hooks/useAuthCheck.js
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 // FPCC
 import { useUserStore } from 'context/UserContext'
 import { isAuthorized, userCanEdit } from 'common/utils/authHelpers'
+import { ASSISTANT } from 'common/constants'
 
 function useAuthCheck() {
   const { user } = useUserStore()
@@ -21,6 +22,8 @@ function useAuthCheck() {
     })
   }
 
+  const checkIfAssistant = () => userMembershipRole === ASSISTANT
+
   const checkIfUserCanEdit = (objectToEdit) =>
     userCanEdit({
       type: objectToEdit?.type,
@@ -29,6 +32,7 @@ function useAuthCheck() {
     })
 
   return {
+    checkIfAssistant,
     checkIfUserAtLeastRole,
     checkIfUserCanEdit,
   }

--- a/src/common/hooks/useAuthCheck.js
+++ b/src/common/hooks/useAuthCheck.js
@@ -1,0 +1,37 @@
+import { useParams } from 'react-router-dom'
+
+// FPCC
+import { useUserStore } from 'context/UserContext'
+import { isAuthorized, userCanEdit } from 'common/utils/authHelpers'
+
+function useAuthCheck() {
+  const { user } = useUserStore()
+  const { sitename } = useParams()
+
+  const userRoles = user?.roles || {}
+  const userMembershipRole = userRoles?.[sitename] || ''
+
+  const checkRoleAuth = (requiredMembershipRole) => {
+    if (user?.isSuperAdmin) {
+      return true
+    }
+    return isAuthorized({
+      requiredMembershipRole,
+      userMembershipRole,
+    })
+  }
+
+  const checkRoleEditAuth = ({ objectToEdit }) =>
+    userCanEdit({
+      type: objectToEdit?.type,
+      visibility: objectToEdit?.visibility,
+      userMembershipRole,
+    })
+
+  return {
+    checkRoleAuth,
+    checkRoleEditAuth,
+  }
+}
+
+export default useAuthCheck

--- a/src/common/utils/authHelpers.js
+++ b/src/common/utils/authHelpers.js
@@ -14,7 +14,15 @@ import {
   atLeastEditor,
   atLeastLanguageAdmin,
   atLeastStaff,
-} from 'common/constants/roles'
+  TYPE_PHRASE,
+  TYPE_SONG,
+  TYPE_STORY,
+  TYPE_WORD,
+  TYPE_AUDIO,
+  TYPE_IMAGE,
+  TYPE_VIDEO,
+  TEAM,
+} from 'common/constants'
 
 function getUser() {
   // Retrieves user tokens directly from local storage.
@@ -71,6 +79,27 @@ export const isAuthorized = ({
     case SUPER_ADMIN:
     case STAFF_ADMIN:
       if (userMembershipRole.match(atLeastStaff)) {
+        return true
+      }
+      return false
+    default:
+      return false
+  }
+}
+
+export const userCanEdit = ({ type, visibility, userMembershipRole }) => {
+  switch (type) {
+    case TYPE_PHRASE:
+    case TYPE_SONG:
+    case TYPE_STORY:
+    case TYPE_WORD:
+    case TYPE_AUDIO:
+    case TYPE_IMAGE:
+    case TYPE_VIDEO:
+      if (userMembershipRole.match(atLeastAssistant) && visibility === TEAM) {
+        return true
+      }
+      if (userMembershipRole.match(atLeastEditor)) {
         return true
       }
       return false

--- a/src/common/utils/authHelpers.js
+++ b/src/common/utils/authHelpers.js
@@ -2,6 +2,19 @@ import { User } from 'oidc-client-ts'
 
 // FPCC
 import GlobalConfiguration from 'src/GlobalConfiguration'
+import {
+  SUPER_ADMIN,
+  STAFF_ADMIN,
+  LANGUAGE_ADMIN,
+  EDITOR,
+  ASSISTANT,
+  MEMBER,
+  atLeastMember,
+  atLeastAssistant,
+  atLeastEditor,
+  atLeastLanguageAdmin,
+  atLeastStaff,
+} from 'common/constants/roles'
 
 function getUser() {
   // Retrieves user tokens directly from local storage.
@@ -28,4 +41,40 @@ export const getAuthHeaderIfTokenExists = () => {
   }
 
   return {}
+}
+
+export const isAuthorized = ({
+  requiredMembershipRole,
+  userMembershipRole,
+}) => {
+  switch (requiredMembershipRole) {
+    case MEMBER:
+      if (userMembershipRole.match(atLeastMember)) {
+        return true
+      }
+      return false
+    case ASSISTANT:
+      if (userMembershipRole.match(atLeastAssistant)) {
+        return true
+      }
+      return false
+    case EDITOR:
+      if (userMembershipRole.match(atLeastEditor)) {
+        return true
+      }
+      return false
+    case LANGUAGE_ADMIN:
+      if (userMembershipRole.match(atLeastLanguageAdmin)) {
+        return true
+      }
+      return false
+    case SUPER_ADMIN:
+    case STAFF_ADMIN:
+      if (userMembershipRole.match(atLeastStaff)) {
+        return true
+      }
+      return false
+    default:
+      return false
+  }
 }

--- a/src/components/App/AppContainer.js
+++ b/src/components/App/AppContainer.js
@@ -101,9 +101,7 @@ function AppContainer() {
                 path="error"
                 element={
                   <AppWrapper>
-                    <ErrorHandler.Container
-                      error={{ status: 404, statusText: 'Page not found' }}
-                    />
+                    <ErrorHandler.Container />
                   </AppWrapper>
                 }
               />

--- a/src/components/App/AppContainer.js
+++ b/src/components/App/AppContainer.js
@@ -19,11 +19,9 @@ import LandingPage from 'components/LandingPage'
 import Languages from 'components/Languages'
 import Loading from 'components/Loading'
 import NotificationBanner from 'components/NotificationBanner'
-import RequireAuth from 'common/RequireAuth'
 import Search from 'components/Search'
 import Site from 'components/Site'
 import Support from 'components/Support'
-import { GENERAL } from 'common/constants/roles'
 import LegacyRedirect from './LegacyRedirect'
 
 function AppContainer() {
@@ -47,9 +45,7 @@ function AppContainer() {
                 path=""
                 element={
                   <AppWrapper isHome>
-                    <RequireAuth siteMembership={GENERAL} withMessage>
-                      <LandingPage.Container />
-                    </RequireAuth>
+                    <LandingPage.Container />
                   </AppWrapper>
                 }
               />

--- a/src/components/Dashboard/DashboardContainer.js
+++ b/src/components/Dashboard/DashboardContainer.js
@@ -12,7 +12,7 @@ import DashboardCreate from 'components/DashboardCreate'
 import DashboardMedia from 'components/DashboardMedia'
 import DashboardReports from 'components/DashboardReports'
 import Loading from 'components/Loading'
-import { ASSISTANT, EDITOR } from 'common/constants/roles'
+import { ASSISTANT } from 'common/constants/roles'
 
 function DashboardContainer() {
   const { currentUser, site, homeTiles, isLoading, logout } = DashboardData()
@@ -56,7 +56,7 @@ function DashboardContainer() {
           <Route
             path="edit/*"
             element={
-              <RequireAuth siteMembership={EDITOR} withMessage>
+              <RequireAuth siteMembership={ASSISTANT} withMessage>
                 <DashboardEdit.Container />
               </RequireAuth>
             }
@@ -72,7 +72,7 @@ function DashboardContainer() {
           <Route
             path="reports/*"
             element={
-              <RequireAuth siteMembership={EDITOR} withMessage>
+              <RequireAuth siteMembership={ASSISTANT} withMessage>
                 <DashboardReports.Container />
               </RequireAuth>
             }
@@ -80,7 +80,7 @@ function DashboardContainer() {
           <Route
             path="advanced-search/*"
             element={
-              <RequireAuth siteMembership={EDITOR} withMessage>
+              <RequireAuth siteMembership={ASSISTANT} withMessage>
                 <DashboardEntries.Container advancedSearch />
               </RequireAuth>
             }

--- a/src/components/Dashboard/DashboardData.js
+++ b/src/components/Dashboard/DashboardData.js
@@ -4,14 +4,18 @@ import { useParams } from 'react-router-dom'
 import { useUserStore } from 'context/UserContext'
 import { useSiteStore } from 'context/SiteContext'
 import {
+  TYPES,
+  TYPE_WORD,
+  TYPE_PHRASE,
   ASSISTANT,
   LANGUAGE_ADMIN,
   MEMBER,
+  VISIBILITY,
+  VISIBILITY_TEAM,
   atLeastAssistant,
-} from 'common/constants/roles'
+} from 'common/constants'
 import { useMySites } from 'common/dataHooks/useMySites'
 import useLoginLogout from 'common/hooks/useLoginLogout'
-import { TYPES, TYPE_WORD, TYPE_PHRASE } from 'common/constants'
 import DashboardEditData from 'components/DashboardEdit/DashboardEditData'
 import DashboardCreateData from 'components/DashboardCreate/DashboardCreateData'
 
@@ -51,7 +55,11 @@ function DashboardData() {
       icon: 'Phrase',
       name: 'Edit words and phrases',
       description: 'Edit the words and phrases in your dictionary',
-      href: `edit/entries?${TYPES}=${TYPE_WORD},${TYPE_PHRASE}`,
+      href: `edit/entries?${TYPES}=${TYPE_WORD},${TYPE_PHRASE}${
+        roles?.[sitename] === ASSISTANT
+          ? `&${VISIBILITY}=${VISIBILITY_TEAM}`
+          : ''
+      }`,
       iconColor: 'phraseText',
       auth: ASSISTANT,
     },

--- a/src/components/Dashboard/DashboardData.js
+++ b/src/components/Dashboard/DashboardData.js
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom'
 import { useUserStore } from 'context/UserContext'
 import { useSiteStore } from 'context/SiteContext'
 import {
-  EDITOR,
+  ASSISTANT,
   LANGUAGE_ADMIN,
   MEMBER,
   atLeastAssistant,
@@ -53,7 +53,7 @@ function DashboardData() {
       description: 'Edit the words and phrases in your dictionary',
       href: `edit/entries?${TYPES}=${TYPE_WORD},${TYPE_PHRASE}`,
       iconColor: 'phraseText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     createTiles.WIDGET,
     editTiles.PAGES,
@@ -65,7 +65,7 @@ function DashboardData() {
         'Saved searches to help you manage dictionary content on your site.',
       href: `reports`,
       iconColor: 'tertiaryB',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'QuestionCircleSolid',

--- a/src/components/Dashboard/DashboardPresentation.js
+++ b/src/components/Dashboard/DashboardPresentation.js
@@ -6,12 +6,13 @@ import PropTypes from 'prop-types'
 import DashboardPresentationSiteSelect from 'components/Dashboard/DashboardPresentationSiteSelect'
 import getIcon from 'common/utils/getIcon'
 import RequireAuth from 'common/RequireAuth'
-import { ASSISTANT, MEMBER, EDITOR } from 'common/constants/roles'
+import { ASSISTANT, MEMBER } from 'common/constants/roles'
 
 function DashboardPresentation({ children, currentUser, site, logout }) {
   const logoutButton = (
     <div className="px-2 py-4 space-y-1">
       <button
+        data-testid="logout-btn"
         type="button"
         onClick={logout}
         className="group flex w-full items-center p-2 text-sm font-medium rounded-lg text-gray-300 hover:bg-fv-charcoal-light hover:text-white"
@@ -79,7 +80,7 @@ const primaryNavigationItems = (currentSitename) => {
       name: 'Edit',
       href: `/${currentSitename}/dashboard/edit`,
       icon: 'Pencil',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       name: 'Media',
@@ -91,7 +92,7 @@ const primaryNavigationItems = (currentSitename) => {
       name: 'Reports',
       href: `/${currentSitename}/dashboard/reports`,
       icon: 'Reports',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
   ]
   return (

--- a/src/components/DashboardEdit/DashboardEditContainer.js
+++ b/src/components/DashboardEdit/DashboardEditContainer.js
@@ -27,7 +27,7 @@ import DashboardImmersiom from 'components/DashboardImmersion'
 import DashboardPages from 'components/DashboardPages'
 import DashboardSpeakers from 'components/DashboardSpeakers'
 import DashboardWidgets from 'components/DashboardWidgets'
-import { EDITOR, LANGUAGE_ADMIN } from 'common/constants/roles'
+import { ASSISTANT, EDITOR, LANGUAGE_ADMIN } from 'common/constants/roles'
 
 function DashboardEditContainer() {
   const { tileContent, headerContent, site } = DashboardEditData({
@@ -56,7 +56,7 @@ function DashboardEditContainer() {
         <Route
           path="entries/*"
           element={
-            <RequireAuth siteMembership={EDITOR} withMessage>
+            <RequireAuth siteMembership={ASSISTANT} withMessage>
               <DashboardEntries.Container />
             </RequireAuth>
           }
@@ -145,7 +145,7 @@ function DashboardEditContainer() {
         <Route
           path="phrase"
           element={
-            <RequireAuth siteMembership={EDITOR} withMessage>
+            <RequireAuth siteMembership={ASSISTANT} withMessage>
               <DictionaryCrud.Container type={TYPE_PHRASE} />
             </RequireAuth>
           }
@@ -153,7 +153,7 @@ function DashboardEditContainer() {
         <Route
           path="song"
           element={
-            <RequireAuth siteMembership={EDITOR} withMessage>
+            <RequireAuth siteMembership={ASSISTANT} withMessage>
               <SongCrud.Container />
             </RequireAuth>
           }
@@ -169,7 +169,7 @@ function DashboardEditContainer() {
         <Route
           path="story"
           element={
-            <RequireAuth siteMembership={EDITOR} withMessage>
+            <RequireAuth siteMembership={ASSISTANT} withMessage>
               <StoryCrud.Container />
             </RequireAuth>
           }
@@ -185,7 +185,7 @@ function DashboardEditContainer() {
         <Route
           path="word"
           element={
-            <RequireAuth siteMembership={EDITOR} withMessage>
+            <RequireAuth siteMembership={ASSISTANT} withMessage>
               <DictionaryCrud.Container type={TYPE_WORD} />
             </RequireAuth>
           }

--- a/src/components/DashboardEdit/DashboardEditData.js
+++ b/src/components/DashboardEdit/DashboardEditData.js
@@ -6,11 +6,18 @@ import {
   TYPE_PHRASE,
   TYPE_SONG,
   TYPE_STORY,
+  ASSISTANT,
+  EDITOR,
+  LANGUAGE_ADMIN,
+  VISIBILITY,
+  VISIBILITY_TEAM,
 } from 'common/constants'
-import { ASSISTANT, EDITOR, LANGUAGE_ADMIN } from 'common/constants/roles'
+import useAuthCheck from 'common/hooks/useAuthCheck'
 
 function DashboardEditData({ urlPrefix = '' }) {
   const { site } = useSiteStore()
+
+  const { checkIfUserAtLeastRole } = useAuthCheck()
 
   function addUrlPrefix(href) {
     if (!urlPrefix) {
@@ -25,7 +32,13 @@ function DashboardEditData({ urlPrefix = '' }) {
       icon: 'Word',
       name: 'Edit words',
       description: 'Edit the words in your dictionary',
-      href: addUrlPrefix(`entries?${TYPES}=${TYPE_WORD}`),
+      href: addUrlPrefix(
+        `entries?${TYPES}=${TYPE_WORD}${
+          checkIfUserAtLeastRole(EDITOR)
+            ? ''
+            : `&${VISIBILITY}=${VISIBILITY_TEAM}`
+        }`,
+      ),
       iconColor: 'wordText',
       auth: ASSISTANT,
     },
@@ -33,7 +46,13 @@ function DashboardEditData({ urlPrefix = '' }) {
       icon: 'Phrase',
       name: 'Edit phrases',
       description: 'Edit the phrases in your dictionary',
-      href: addUrlPrefix(`entries?${TYPES}=${TYPE_PHRASE}`),
+      href: addUrlPrefix(
+        `entries?${TYPES}=${TYPE_PHRASE}${
+          checkIfUserAtLeastRole(EDITOR)
+            ? ''
+            : `&${VISIBILITY}=${VISIBILITY_TEAM}`
+        }`,
+      ),
       iconColor: 'phraseText',
       auth: ASSISTANT,
     },
@@ -41,7 +60,13 @@ function DashboardEditData({ urlPrefix = '' }) {
       icon: 'Song',
       name: 'Edit songs',
       description: 'Edit the songs on your site',
-      href: addUrlPrefix(`entries?${TYPES}=${TYPE_SONG}`),
+      href: addUrlPrefix(
+        `entries?${TYPES}=${TYPE_SONG}${
+          checkIfUserAtLeastRole(EDITOR)
+            ? ''
+            : `&${VISIBILITY}=${VISIBILITY_TEAM}`
+        }`,
+      ),
       iconColor: 'songText',
       auth: ASSISTANT,
     },
@@ -49,7 +74,13 @@ function DashboardEditData({ urlPrefix = '' }) {
       icon: 'Story',
       name: 'Edit stories',
       description: 'Edit the stories on your site',
-      href: addUrlPrefix(`entries?${TYPES}=${TYPE_STORY}`),
+      href: addUrlPrefix(
+        `entries?${TYPES}=${TYPE_STORY}${
+          checkIfUserAtLeastRole(EDITOR)
+            ? ''
+            : `&${VISIBILITY}=${VISIBILITY_TEAM}`
+        }`,
+      ),
       iconColor: 'storyText',
       auth: ASSISTANT,
     },

--- a/src/components/DashboardEdit/DashboardEditData.js
+++ b/src/components/DashboardEdit/DashboardEditData.js
@@ -7,7 +7,7 @@ import {
   TYPE_SONG,
   TYPE_STORY,
 } from 'common/constants'
-import { EDITOR, LANGUAGE_ADMIN } from 'common/constants/roles'
+import { ASSISTANT, EDITOR, LANGUAGE_ADMIN } from 'common/constants/roles'
 
 function DashboardEditData({ urlPrefix = '' }) {
   const { site } = useSiteStore()
@@ -27,7 +27,7 @@ function DashboardEditData({ urlPrefix = '' }) {
       description: 'Edit the words in your dictionary',
       href: addUrlPrefix(`entries?${TYPES}=${TYPE_WORD}`),
       iconColor: 'wordText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     PHRASES: {
       icon: 'Phrase',
@@ -35,7 +35,7 @@ function DashboardEditData({ urlPrefix = '' }) {
       description: 'Edit the phrases in your dictionary',
       href: addUrlPrefix(`entries?${TYPES}=${TYPE_PHRASE}`),
       iconColor: 'phraseText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     SONGS: {
       icon: 'Song',
@@ -43,7 +43,7 @@ function DashboardEditData({ urlPrefix = '' }) {
       description: 'Edit the songs on your site',
       href: addUrlPrefix(`entries?${TYPES}=${TYPE_SONG}`),
       iconColor: 'songText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     STORIES: {
       icon: 'Story',
@@ -51,7 +51,7 @@ function DashboardEditData({ urlPrefix = '' }) {
       description: 'Edit the stories on your site',
       href: addUrlPrefix(`entries?${TYPES}=${TYPE_STORY}`),
       iconColor: 'storyText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     SPEAKERS: {
       icon: 'Speak',

--- a/src/components/DashboardEntries/DashboardEntriesData.js
+++ b/src/components/DashboardEntries/DashboardEntriesData.js
@@ -55,9 +55,7 @@ function DashboardEntriesData({ advancedSearch }) {
   }
 
   return {
-    emptyListMessage: searchTerm
-      ? 'Sorry, there are no results for this search.'
-      : 'Please enter your search above.',
+    emptyListMessage: 'Sorry, no results match your search criteria.',
     entryLabel: getSearchTypeLabel({ searchType }),
     infiniteScroll,
     initialSearchType: urlSearchType,

--- a/src/components/DashboardEntries/DashboardEntriesPresentationList.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentationList.js
@@ -9,6 +9,7 @@ import getIcon from 'common/utils/getIcon'
 import Drawer from 'components/Drawer'
 import { makePlural } from 'common/utils/urlHelpers'
 import SortByHeader from 'components/DashboardEntries/SortByHeader'
+import useAuthCheck from 'common/hooks/useAuthCheck'
 import {
   SORT_ALPHABETICAL,
   SORT_ALPHABETICAL_DESC,
@@ -29,6 +30,7 @@ function DashboardEntriesPresentationList({
   const [selectedItem, setSelectedItem] = useState({})
   const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
   const { sitename } = useParams()
+  const { checkIfUserCanEdit } = useAuthCheck()
 
   const getLoadLabel = () => {
     if (infiniteScroll?.isFetchingNextPage) {
@@ -164,14 +166,16 @@ function DashboardEntriesPresentationList({
                             </span>
                           </td>
                           <td>
-                            <Link
-                              to={`/${sitename}/dashboard/edit/${entry?.type}?id=${entry?.id}`}
-                              className="p-4 text-primary hover:text-primary-dark flex items-center"
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {getIcon('Pencil', 'fill-current w-6 h-6')}
-                            </Link>
+                            {checkIfUserCanEdit(entry) && (
+                              <Link
+                                to={`/${sitename}/dashboard/edit/${entry?.type}?id=${entry?.id}`}
+                                className="p-4 text-primary hover:text-primary-dark flex items-center"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {getIcon('Pencil', 'fill-current w-6 h-6')}
+                              </Link>
+                            )}
                           </td>
                           <td>
                             <button
@@ -222,17 +226,18 @@ function DashboardEntriesPresentationList({
         {selectedItem?.type && (
           <>
             <div className="flex justify-center my-2 space-x-2">
-              <Link
-                to={`/${sitename}/dashboard/edit/${selectedItem?.type}?id=${selectedItem?.id}`}
-                data-testid="EntryDrawerEdit"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="btn-outlined"
-              >
-                {getIcon('Pencil', 'btn-icon')}
-                <span>Edit</span>
-              </Link>
-
+              {checkIfUserCanEdit(selectedItem) && (
+                <Link
+                  to={`/${sitename}/dashboard/edit/${selectedItem?.type}?id=${selectedItem?.id}`}
+                  data-testid="EntryDrawerEdit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn-outlined"
+                >
+                  {getIcon('Pencil', 'btn-icon')}
+                  <span>Edit</span>
+                </Link>
+              )}
               <Link
                 to={`/${sitename}/${makePlural(selectedItem?.type)}/${
                   selectedItem?.id

--- a/src/components/DashboardEntries/DashboardEntriesPresentationList.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentationList.js
@@ -134,7 +134,7 @@ function DashboardEntriesPresentationList({
                             {entry?.translations && (
                               <ol className="text-fv-charcoal">
                                 {entry?.translations.map((translation, i) => (
-                                  <li key={translation?.id}>
+                                  <li key={translation?.text}>
                                     {entry?.translations.length > 1
                                       ? `${i + 1}. `
                                       : null}{' '}

--- a/src/components/DashboardReports/DashboardReportsData.js
+++ b/src/components/DashboardReports/DashboardReportsData.js
@@ -14,7 +14,7 @@ import {
   VISIBILITY_MEMBERS,
   VISIBILITY_TEAM,
 } from 'common/constants'
-import { EDITOR } from 'common/constants/roles'
+import { ASSISTANT } from 'common/constants/roles'
 
 function DashboardReportsData() {
   const { site } = useSiteStore()
@@ -26,7 +26,7 @@ function DashboardReportsData() {
       description: 'Use the advanced search filters to create your own report',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}`,
       iconColor: 'wordText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
   ]
 
@@ -37,7 +37,7 @@ function DashboardReportsData() {
       description: 'New words and phrases at the top',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${SORT}=${SORT_CREATED_DESC}`,
       iconColor: 'story',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'Pencil',
@@ -45,7 +45,7 @@ function DashboardReportsData() {
       description: 'Recently edited words and phrases at the top',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${SORT}=${SORT_MODIFIED_DESC}`,
       iconColor: 'word',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'MicrophoneOff',
@@ -53,7 +53,7 @@ function DashboardReportsData() {
       description: 'Words and phrases without audio files',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${HAS_AUDIO}=${FALSE}`,
       iconColor: 'song',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'ImagesNone',
@@ -61,7 +61,7 @@ function DashboardReportsData() {
       description: 'Words and phrases without images',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${HAS_IMAGE}=${FALSE}`,
       iconColor: 'phrase',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'Team',
@@ -69,7 +69,7 @@ function DashboardReportsData() {
       description: 'Content only available to the language team',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${VISIBILITY}=${VISIBILITY_TEAM}`,
       iconColor: 'phraseText',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'Members',
@@ -77,7 +77,7 @@ function DashboardReportsData() {
       description: 'Content only available to site members',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${VISIBILITY}=${VISIBILITY_MEMBERS}`,
       iconColor: 'tertiaryA',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
     {
       icon: 'Public',
@@ -85,7 +85,7 @@ function DashboardReportsData() {
       description: 'Content available to the general public',
       href: `/${site?.sitename}/dashboard/advanced-search?${TYPES}=${TYPE_DICTIONARY}&${VISIBILITY}=${VISIBILITY_PUBLIC}`,
       iconColor: 'tertiaryB',
-      auth: EDITOR,
+      auth: ASSISTANT,
     },
   ]
 

--- a/src/components/DeleteButton/DeleteButtonPresentation.js
+++ b/src/components/DeleteButton/DeleteButtonPresentation.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types'
 // FPCC
 import getIcon from 'common/utils/getIcon'
 import Modal from 'components/Modal'
+import useAuthCheck from 'common/hooks/useAuthCheck'
+import { EDITOR } from 'common/constants'
 
 function DeleteButtonPresentation({
   deleteHandler,
@@ -13,58 +15,62 @@ function DeleteButtonPresentation({
   styling = 'btn-outlined',
 }) {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const { checkIfUserAtLeastRole } = useAuthCheck()
+  const atLeastEditor = checkIfUserAtLeastRole(EDITOR)
 
   return (
-    <>
-      <button
-        data-testid="DeleteButton"
-        type="button"
-        onClick={() => setDeleteModalOpen(true)}
-        className={styling}
-      >
-        {getIcon('Trash', 'btn-icon')}
-        <span>{label}</span>
-      </button>
-
-      <Modal.Presentation
-        isOpen={deleteModalOpen}
-        closeHandler={() => setDeleteModalOpen(false)}
-      >
-        <div
-          data-testid="DeleteModal"
-          className="inline-block align-bottom space-y-5 bg-white rounded-lg p-6 lg:p-8 overflow-hidden shadow-xl transform transition-all sm:align-middle sm:max-w-sm sm:w-full"
+    atLeastEditor && (
+      <>
+        <button
+          data-testid="DeleteButton"
+          type="button"
+          onClick={() => setDeleteModalOpen(true)}
+          className={styling}
         >
-          <div className="text-center space-y-2">
-            <p className="text-2xl text-fv-charcoal">{message}</p>
-            {note && <p className="text-fv-charcoal-light">{note}</p>}
-            <p className="text-fv-charcoal-light">
-              You can&apos;t undo this action.
-            </p>
+          {getIcon('Trash', 'btn-icon')}
+          <span>{label}</span>
+        </button>
+
+        <Modal.Presentation
+          isOpen={deleteModalOpen}
+          closeHandler={() => setDeleteModalOpen(false)}
+        >
+          <div
+            data-testid="DeleteModal"
+            className="inline-block align-bottom space-y-5 bg-white rounded-lg p-6 lg:p-8 overflow-hidden shadow-xl transform transition-all sm:align-middle sm:max-w-sm sm:w-full"
+          >
+            <div className="text-center space-y-2">
+              <p className="text-2xl text-fv-charcoal">{message}</p>
+              {note && <p className="text-fv-charcoal-light">{note}</p>}
+              <p className="text-fv-charcoal-light">
+                You can&apos;t undo this action.
+              </p>
+            </div>
+            <div className="w-full justify-center flex space-x-2">
+              <button
+                data-testid="delete-cancel"
+                type="button"
+                className="btn-outlined"
+                onClick={() => setDeleteModalOpen(false)}
+              >
+                Cancel
+              </button>
+              <button
+                data-testid="delete-confirm"
+                type="button"
+                className="btn-contained bg-secondary"
+                onClick={() => {
+                  setDeleteModalOpen(false)
+                  deleteHandler()
+                }}
+              >
+                Delete
+              </button>
+            </div>
           </div>
-          <div className="w-full justify-center flex space-x-2">
-            <button
-              data-testid="delete-cancel"
-              type="button"
-              className="btn-outlined"
-              onClick={() => setDeleteModalOpen(false)}
-            >
-              Cancel
-            </button>
-            <button
-              data-testid="delete-confirm"
-              type="button"
-              className="btn-contained bg-secondary"
-              onClick={() => {
-                setDeleteModalOpen(false)
-                deleteHandler()
-              }}
-            >
-              Delete
-            </button>
-          </div>
-        </div>
-      </Modal.Presentation>
-    </>
+        </Modal.Presentation>
+      </>
+    )
   )
 }
 // PROPTYPES

--- a/src/components/ErrorHandler/ErrorHandlerData.js
+++ b/src/components/ErrorHandler/ErrorHandlerData.js
@@ -24,7 +24,7 @@ function ErrorHandlerData() {
   }, [goBack])
 
   return {
-    errorStatusCode: parseInt(status),
+    errorStatusCode: parseInt(status, 10),
     errorStatusText: statusText,
     backHandler,
   }

--- a/src/components/Form/CategoryArrayField.js
+++ b/src/components/Form/CategoryArrayField.js
@@ -34,10 +34,7 @@ function CategoryArrayField({
       <div className="space-y-2 mt-1">
         <ul className="space-y-2 space-x-1">
           {fields.map((item, index) => (
-            <li
-              key={item.id}
-              className="btn-contained bg-tertiaryB hover:bg-tertiaryB-dark"
-            >
+            <li key={item.id} className="btn-contained">
               <input type="hidden" {...register(`${nameId}.${index}`)} />
               <div>{item?.title}</div>
               <div className="has-tooltip flex items-center">

--- a/src/components/Form/CategoryArrayField.js
+++ b/src/components/Form/CategoryArrayField.js
@@ -32,9 +32,9 @@ function CategoryArrayField({
         {label}
       </label>
       <div className="space-y-2 mt-1">
-        <ul className="space-y-2 space-x-1">
+        <ul className="space-y-2">
           {fields.map((item, index) => (
-            <li key={item.id} className="btn-contained">
+            <li key={item.id} className="btn-contained mr-1">
               <input type="hidden" {...register(`${nameId}.${index}`)} />
               <div>{item?.title}</div>
               <div className="has-tooltip flex items-center">

--- a/src/components/Form/CategoryArrayField.js
+++ b/src/components/Form/CategoryArrayField.js
@@ -36,21 +36,22 @@ function CategoryArrayField({
           {fields.map((item, index) => (
             <li
               key={item.id}
-              className="p-1 inline-flex items-center rounded-lg shadow-md bg-tertiaryB hover:bg-tertiaryB-dark text-white space-x-1"
+              className="btn-contained bg-tertiaryB hover:bg-tertiaryB-dark"
             >
               <input type="hidden" {...register(`${nameId}.${index}`)} />
-              <div className="font-bold text-sm">{item?.title}</div>
+              <div>{item?.title}</div>
               <div className="has-tooltip flex items-center">
-                <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-12">
+                <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-14">
                   Remove from category
                 </span>
                 <button
                   type="button"
+                  data-testid={`remove-category-btn-${item?.id}`}
                   aria-label="Remove from category"
-                  className="border p-1 border-transparent inline-flex items-center rounded-lg"
+                  className="border p-1 -m-1 border-transparent inline-flex items-center rounded-lg"
                   onClick={() => remove(index)}
                 >
-                  {getIcon('Close', 'fill-current text-white h-6 w-6')}
+                  {getIcon('Close', 'btn-icon')}
                 </button>
               </div>
             </li>

--- a/src/components/Form/EntryArrayField.js
+++ b/src/components/Form/EntryArrayField.js
@@ -39,27 +39,25 @@ function EntryArrayField({
       <div className="space-y-2 mt-2">
         <ul className="space-y-2 space-x-1">
           {fields.map((field, index) => (
-            <li
-              key={field.id}
-              className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1"
-            >
+            <li key={field.id} className="btn-contained">
               <input
                 key={field.id}
                 type="hidden"
                 {...register(`${nameId}.${index}.value`)}
               />
-              <div className="font-bold text-lg">{field?.title}</div>
+              <div>{field?.title}</div>
               <div className="has-tooltip flex items-center">
-                <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-12">
+                <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-primary text-xs -mt-14">
                   Remove
                 </span>
                 <button
+                  data-testid={`remove-entry-btn-${field?.id}`}
                   type="button"
                   aria-label="Remove"
-                  className="-mr-1.5 border p-1 border-transparent inline-flex items-center rounded-lg text-sm font-bold text-fv-charcoal hover:bg-gray-300"
+                  className="border p-1 border-transparent inline-flex items-center rounded-lg"
                   onClick={() => remove(index)}
                 >
-                  {getIcon('Close', 'fill-current text-fv-charcoal h-5 w-5')}
+                  {getIcon('Close', 'btn-icon')}
                 </button>
               </div>
             </li>

--- a/src/components/Form/EntryArrayField.js
+++ b/src/components/Form/EntryArrayField.js
@@ -37,9 +37,9 @@ function EntryArrayField({
         {label}
       </label>
       <div className="space-y-2 mt-2">
-        <ul className="space-y-2 space-x-1">
+        <ul className="space-y-1">
           {fields.map((field, index) => (
-            <li key={field.id} className="btn-contained">
+            <li key={field.id} className="btn-contained mr-1">
               <input
                 key={field.id}
                 type="hidden"

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types'
 // FPCC
 import Select from 'components/Form/Select'
 import { useSiteStore } from 'context/SiteContext'
-import { useUserStore } from 'context/UserContext'
-import { TEAM, ASSISTANT } from 'common/constants'
+import useAuthCheck from 'common/hooks/useAuthCheck'
+import { TEAM } from 'common/constants'
 import { formattedVisibilityOptions } from 'common/dataAdaptors/siteAdaptors'
 
 function Visibility({
@@ -15,38 +15,31 @@ function Visibility({
   resetField,
 } = {}) {
   const { site } = useSiteStore()
-  const { user } = useUserStore()
-  const userRoles = user?.roles || {}
-  const userSiteRole = userRoles?.[site?.sitename] || ''
-  const isAssistant = userSiteRole === ASSISTANT
-
-  const options = (function _() {
-    if (isAssistant) {
-      return formattedVisibilityOptions([TEAM])
-    }
-    return site?.visibilityOptions
-  })()
+  const { checkIfAssistant } = useAuthCheck()
+  const isAssistant = checkIfAssistant()
 
   useEffect(() => {
+    const defaultValue = isAssistant ? TEAM : site?.visibilityOptions[0]?.value
     // set default value to match visibility options
-    resetField('visibility', { defaultValue: options[0]?.value })
-  }, [options, resetField])
+    resetField('visibility', { defaultValue })
+  }, [site?.visibilityOptions, isAssistant, resetField])
+
+  const options = isAssistant
+    ? formattedVisibilityOptions([TEAM])
+    : site?.visibilityOptions
 
   return (
-    site?.visibilityOptions &&
-    userSiteRole && (
-      <Fragment key="FormVisibility">
-        <Select
-          label={label}
-          control={control}
-          nameId="visibility"
-          options={options}
-        />
-        {errors?.visibility && (
-          <div className="text-red-500">{errors?.visibility?.message}</div>
-        )}
-      </Fragment>
-    )
+    <Fragment key="FormVisibility">
+      <Select
+        label={label}
+        control={control}
+        nameId="visibility"
+        options={options}
+      />
+      {errors?.visibility && (
+        <div className="text-red-500">{errors?.visibility?.message}</div>
+      )}
+    </Fragment>
   )
 }
 // PROPTYPES

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -29,17 +29,18 @@ function Visibility({
     : site?.visibilityOptions
 
   return (
-    <Fragment key="FormVisibility">
-      <Select
-        label={label}
-        control={control}
-        nameId="visibility"
-        options={options}
-      />
-      {errors?.visibility && (
-        <div className="text-red-500">{errors?.visibility?.message}</div>
-      )}
-    </Fragment>
+    <Select
+      label={label}
+      control={control}
+      nameId="visibility"
+      options={options}
+      errors={errors}
+      helpText={
+        isAssistant
+          ? 'Please contact an Editor or Administrator from your team to change the visibility.'
+          : ''
+      }
+    />
   )
 }
 // PROPTYPES

--- a/src/components/SearchDomainSelector/SearchDomainSelectorPresentation.js
+++ b/src/components/SearchDomainSelector/SearchDomainSelectorPresentation.js
@@ -62,11 +62,11 @@ function SearchDomainSelectorPresentation({
   )
 }
 // PROPTYPES
-const { array, func, string } = PropTypes
+const { object, func, string } = PropTypes
 SearchDomainSelectorPresentation.propTypes = {
   searchDomain: string,
   handleSearchDomainChange: func,
-  searchDomainOptions: array,
+  searchDomainOptions: object,
 }
 
 export default SearchDomainSelectorPresentation

--- a/src/components/SearchForm/SearchForm.js
+++ b/src/components/SearchForm/SearchForm.js
@@ -55,7 +55,7 @@ function SearchForm({
 }
 
 // PROPTYPES
-const { func, string } = PropTypes
+const { func, object, string } = PropTypes
 SearchForm.propTypes = {
   handleSearchNavigation: func,
   handleSearchTermChange: func,
@@ -63,7 +63,7 @@ SearchForm.propTypes = {
   searchBoxPlaceholder: string,
   searchDomain: string,
   handleSearchDomainChange: func,
-  searchDomainOptions: string,
+  searchDomainOptions: object,
 }
 
 export default SearchForm


### PR DESCRIPTION
### Description of Changes

1.     Add Word and Phrase tiles on Edit and Create pages in the dashboard for Assistants
2.     Only show edit links in the list view for entries that are team-only for Assistants.
3.     Only show the edit button on the dashboard detail view for entries that are team-only for Assistants
4.     Remove the delete button on dictionary entry forms for Assistants
5.     Restrict the visibility selector for assistants on dictionary forms and ensure it only allows team-only

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
