### PR TITLE
FW-6025, FW-6026 assistants edit team only songs and stories

### DIFF
--- a/src/common/dataHooks/useSongs.js
+++ b/src/common/dataHooks/useSongs.js
@@ -3,13 +3,20 @@ import { useParams } from 'react-router-dom'
 
 // FPCC
 import api from 'services/api'
-import { SONGS, TYPE_SONG } from 'common/constants'
+import {
+  SONGS,
+  TYPES,
+  TYPE_SONG,
+  VISIBILITY,
+  VISIBILITY_TEAM,
+} from 'common/constants'
 import {
   songForViewing,
   songForEditing,
   songForApi,
 } from 'common/dataAdaptors/songAdaptors'
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
+import useAuthCheck from 'common/hooks/useAuthCheck'
 
 export function useSongs() {
   const { sitename } = useParams()
@@ -70,9 +77,13 @@ export function useSongCreate() {
     })
   }
 
+  const { checkIfAssistant } = useAuthCheck()
+
   const mutation = useMutationWithNotification({
     mutationFn: createSong,
-    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
+    redirectTo: `/${sitename}/dashboard/edit/entries?${TYPES}=${TYPE_SONG}${
+      checkIfAssistant() ? `&${VISIBILITY}=${VISIBILITY_TEAM}` : ''
+    }`,
     queryKeyToInvalidate: [SONGS, sitename],
     actionWord: 'created',
     type: 'song',
@@ -96,9 +107,13 @@ export function useSongUpdate() {
     })
   }
 
+  const { checkIfAssistant } = useAuthCheck()
+
   const mutation = useMutationWithNotification({
     mutationFn: updateSong,
-    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
+    redirectTo: `/${sitename}/dashboard/edit/entries?${TYPES}=${TYPE_SONG}${
+      checkIfAssistant() ? `&${VISIBILITY}=${VISIBILITY_TEAM}` : ''
+    }`,
     queryKeyToInvalidate: [SONGS, sitename],
     actionWord: 'updated',
     type: 'song',
@@ -120,7 +135,7 @@ export function useSongDelete() {
 
   const mutation = useMutationWithNotification({
     mutationFn: deleteSong,
-    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
+    redirectTo: `/${sitename}/dashboard/edit/entries?${TYPES}=${TYPE_SONG}`,
     queryKeyToInvalidate: [SONGS, sitename],
     actionWord: 'deleted',
     type: 'song',

--- a/src/common/dataHooks/useSongs.js
+++ b/src/common/dataHooks/useSongs.js
@@ -10,8 +10,6 @@ import {
   songForApi,
 } from 'common/dataAdaptors/songAdaptors'
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
-import { useUserStore } from 'context/UserContext'
-import { ASSISTANT } from 'common/constants/roles'
 
 export function useSongs() {
   const { sitename } = useParams()
@@ -72,16 +70,9 @@ export function useSongCreate() {
     })
   }
 
-  const { user } = useUserStore()
-  const userRoles = user?.roles || {}
-  const userSiteRole = userRoles?.[sitename] || ''
-  const isAssistant = userSiteRole === ASSISTANT
-
   const mutation = useMutationWithNotification({
     mutationFn: createSong,
-    redirectTo: isAssistant // Redirect to the create page for assistants to be removed when assistants can access the edit pages (FW-4828)
-      ? `/${sitename}/dashboard/create`
-      : `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
+    redirectTo: `/${sitename}/dashboard/edit/entries?types=${TYPE_SONG}`,
     queryKeyToInvalidate: [SONGS, sitename],
     actionWord: 'created',
     type: 'song',

--- a/src/components/DashboardEntries/DashboardEntriesPresentationList.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentationList.js
@@ -166,7 +166,7 @@ function DashboardEntriesPresentationList({
                             </span>
                           </td>
                           <td>
-                            {checkIfUserCanEdit(entry) && (
+                            {checkIfUserCanEdit(entry) ? (
                               <Link
                                 to={`/${sitename}/dashboard/edit/${entry?.type}?id=${entry?.id}`}
                                 className="p-4 text-primary hover:text-primary-dark flex items-center"
@@ -175,6 +175,13 @@ function DashboardEntriesPresentationList({
                               >
                                 {getIcon('Pencil', 'fill-current w-6 h-6')}
                               </Link>
+                            ) : (
+                              <div className="has-tooltip p-4 text-gray-400 flex items-center">
+                                <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-fv-charcoal text-xs -mt-10 -ml-20">
+                                  You do not have access to edit this.
+                                </span>
+                                {getIcon('Pencil', 'fill-current w-6 h-6')}
+                              </div>
                             )}
                           </td>
                           <td>
@@ -226,7 +233,7 @@ function DashboardEntriesPresentationList({
         {selectedItem?.type && (
           <>
             <div className="flex justify-center my-2 space-x-2">
-              {checkIfUserCanEdit(selectedItem) && (
+              {checkIfUserCanEdit(selectedItem) ? (
                 <Link
                   to={`/${sitename}/dashboard/edit/${selectedItem?.type}?id=${selectedItem?.id}`}
                   data-testid="EntryDrawerEdit"
@@ -237,6 +244,14 @@ function DashboardEntriesPresentationList({
                   {getIcon('Pencil', 'btn-icon')}
                   <span>Edit</span>
                 </Link>
+              ) : (
+                <div className="has-tooltip btn-outlined text-gray-400 border-gray-400">
+                  <span className="tooltip rounded shadow-lg p-1 bg-gray-100 text-fv-charcoal text-xs -mt-10 -ml-10">
+                    You do not have access to edit this.
+                  </span>
+                  {getIcon('Pencil', 'btn-icon')}
+                  <span>Edit</span>
+                </div>
               )}
               <Link
                 to={`/${sitename}/${makePlural(selectedItem?.type)}/${

--- a/src/components/Form/NextPrevious.js
+++ b/src/components/Form/NextPrevious.js
@@ -5,6 +5,13 @@ import { Link } from 'react-router-dom'
 // FPCC
 import getIcon from 'common/utils/getIcon'
 import useSearchParamsState from 'common/hooks/useSearchParamsState'
+import useAuthCheck from 'common/hooks/useAuthCheck'
+import {
+  TYPES,
+  TYPE_STORY,
+  VISIBILITY,
+  VISIBILITY_TEAM,
+} from 'common/constants'
 
 function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
   const [activeStep, setActiveStep] = useSearchParamsState({
@@ -20,6 +27,8 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
     }
     return setActiveStep(String(stepToGoTo))
   }
+
+  const { checkIfAssistant } = useAuthCheck()
 
   return (
     <div className="flex w-full justify-between p-2">
@@ -48,7 +57,9 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
       ) : (
         <div className="flex w-full justify-end">
           <Link
-            to={`/${sitename}/dashboard/edit/entries?types=story`}
+            to={`/${sitename}/dashboard/edit/entries?${TYPES}=${TYPE_STORY}${
+              checkIfAssistant() ? `&${VISIBILITY}=${VISIBILITY_TEAM}` : ''
+            }`}
             className="btn-contained bg-secondary"
           >
             <span>Finish</span>

--- a/src/components/Form/NextPrevious.js
+++ b/src/components/Form/NextPrevious.js
@@ -5,8 +5,6 @@ import { Link } from 'react-router-dom'
 // FPCC
 import getIcon from 'common/utils/getIcon'
 import useSearchParamsState from 'common/hooks/useSearchParamsState'
-import { useUserStore } from 'context/UserContext'
-import { ASSISTANT } from 'common/constants/roles'
 
 function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
   const [activeStep, setActiveStep] = useSearchParamsState({
@@ -18,14 +16,10 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
   const onStepClick = ({ forward }) => {
     const stepToGoTo = forward ? activeStepNumber + 1 : activeStepNumber - 1
     if (onClickCallback) {
-      onClickCallback(String(stepToGoTo))
-    } else return setActiveStep(String(stepToGoTo))
+      return onClickCallback(String(stepToGoTo))
+    }
+    return setActiveStep(String(stepToGoTo))
   }
-
-  const { user } = useUserStore()
-  const userRoles = user?.roles || {}
-  const userSiteRole = userRoles?.[sitename] || ''
-  const isAssistant = userSiteRole === ASSISTANT
 
   return (
     <div className="flex w-full justify-between p-2">
@@ -54,11 +48,7 @@ function NextPrevious({ numberOfSteps, onClickCallback, sitename }) {
       ) : (
         <div className="flex w-full justify-end">
           <Link
-            to={
-              isAssistant // Redirect to the create page for assistants to be removed when assistants can access the edit pages (FW-4828)
-                ? `/${sitename}/dashboard/create`
-                : `/${sitename}/dashboard/edit/entries?types=story`
-            }
+            to={`/${sitename}/dashboard/edit/entries?types=story`}
             className="btn-contained bg-secondary"
           >
             <span>Finish</span>


### PR DESCRIPTION
### Description of Changes

- update redirects for Assistants to redirect to edit page with filter "TEAM" (after saving songs and stories)
- Add disabled buttons with tool-tips in place of edit buttons on Public and Members entries for Assistants

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
