### PR TITLE
FW-6157 shared image thumbnails

### DIFF
--- a/src/common/dataAdaptors/galleryAdaptors.js
+++ b/src/common/dataAdaptors/galleryAdaptors.js
@@ -18,8 +18,8 @@ export function galleryForEditing({ item }) {
     ...titleForEditing({ item }),
     intro: item?.introduction,
     introTranslation: item?.introductionTranslation,
-    coverImage: item?.coverImage?.id,
-    galleryItems: objectsToIdsAdaptor(item?.galleryItems),
+    coverImage: item?.coverImage?.id ? [item?.coverImage] : [],
+    galleryItems: item?.galleryItems,
   }
 }
 
@@ -29,7 +29,7 @@ export function galleryForApi({ formData }) {
     ...titleForApi({ item: formData }),
     introduction: formData?.intro,
     introduction_translation: formData?.introTranslation,
-    cover_image: formData?.coverImage,
-    gallery_items: formData?.galleryItems,
+    cover_image: formData?.coverImage?.[0]?.id || '',
+    gallery_items: objectsToIdsAdaptor(formData?.galleryItems),
   }
 }

--- a/src/common/dataAdaptors/relatedMediaAdaptors.js
+++ b/src/common/dataAdaptors/relatedMediaAdaptors.js
@@ -24,8 +24,8 @@ export function relatedMediaForEditing({ item }) {
   }))
   return {
     relatedAudio: objectsToIdsAdaptor(item?.relatedAudio),
-    relatedImages: objectsToIdsAdaptor(item?.relatedImages),
-    relatedVideos: objectsToIdsAdaptor(item?.relatedVideos),
+    relatedImages: item?.relatedImages || [],
+    relatedVideos: item?.relatedVideos || [],
     relatedVideoLinks: relatedVideoLinks || [],
   }
 }
@@ -34,8 +34,8 @@ export function relatedMediaForApi({ item }) {
   const relatedVideoLinks = item?.relatedVideoLinks?.map((el) => el.text)
   return {
     related_audio: item?.relatedAudio || [],
-    related_images: item?.relatedImages || [],
-    related_videos: item?.relatedVideos || [],
+    related_images: objectsToIdsAdaptor(item?.relatedImages),
+    related_videos: objectsToIdsAdaptor(item?.relatedVideos),
     related_video_links: relatedVideoLinks || [],
   }
 }

--- a/src/common/dataAdaptors/siteAdaptors.js
+++ b/src/common/dataAdaptors/siteAdaptors.js
@@ -90,6 +90,7 @@ const logoAdaptor = ({ item }) => {
   const logoObject = {
     logo: item?.logo,
     logoId: item?.logo?.id,
+    logoArray: item?.logo?.id ? [item?.logo] : [],
   }
   return logoObject
 }

--- a/src/common/dataHooks/useCreateUppy.js
+++ b/src/common/dataHooks/useCreateUppy.js
@@ -94,11 +94,11 @@ function useCreateUppy(site, maxItems, setSelectedMedia, type) {
     fieldName: 'original',
     formData: true,
     headers: getAuthHeaderIfTokenExists(),
-    getResponseData: (responseText) => {
-      const _responseText = JSON.parse(responseText)
-      setSelectedMedia((oldArray) => [...oldArray, _responseText?.id])
+    getResponseData: (response) => {
+      const parsedResponse = JSON.parse(response)
+      setSelectedMedia((oldArray) => [...oldArray, parsedResponse])
       return {
-        url: _responseText?.url,
+        url: parsedResponse?.url,
       }
     },
   })

--- a/src/common/dataHooks/useSites.js
+++ b/src/common/dataHooks/useSites.js
@@ -43,7 +43,7 @@ export function useSiteUpdateBanner() {
   const updateBanner = async (formData) => {
     const bannerObject = selectOneMediaFormHelper(formData?.banner)
     const properties = {
-      logo: formData?.logoId || null,
+      logo: formData?.logoArray?.[0]?.id || null,
       bannerImage: bannerObject?.imageId || null,
       bannerVideo: bannerObject?.videoId || null,
     }

--- a/src/common/hooks/useArrayStateManager.js
+++ b/src/common/hooks/useArrayStateManager.js
@@ -7,7 +7,7 @@ function useArrayStateManager({ maxItems }) {
   const removeItemFromArray = (array, item) =>
     [...array].filter((elem) => elem !== item && elem?.id !== item?.id)
 
-  const hasItem = (array, item) =>
+  const checkForItem = (array, item) =>
     array.some((elem) => elem === item || elem?.id === item?.id)
 
   const handleSelectAdditionalItems = (selectedItem) => {
@@ -16,8 +16,11 @@ function useArrayStateManager({ maxItems }) {
       return
     }
 
-    if (maxItems && selectedItems.length === maxItems) return
+    if (maxItems && selectedItems.length >= maxItems) {
+      return
+    }
 
+    const hasItem = checkForItem(selectedItems, selectedItem)
     if (hasItem) {
       setSelectedItems(removeItemFromArray(selectedItems, selectedItem))
       return

--- a/src/common/hooks/useArrayStateManager.js
+++ b/src/common/hooks/useArrayStateManager.js
@@ -4,20 +4,21 @@ import PropTypes from 'prop-types'
 function useArrayStateManager({ maxItems }) {
   const [selectedItems, setSelectedItems] = useState([])
 
-  const handleSelectAdditionalItems = (id) => {
+  const removeItem = (array, item) =>
+    array.filter((elem) => elem !== item && elem?.id !== item?.id)
+
+  const handleSelectAdditionalItems = (item) => {
     let updatedSelectedItems = [...selectedItems]
-    if (selectedItems.some((elemId) => elemId === id)) {
-      updatedSelectedItems = updatedSelectedItems.filter(
-        (elemId) => elemId !== id,
-      )
+    if (selectedItems.some((elem) => elem === item || elem?.id === item?.id)) {
+      updatedSelectedItems = removeItem(updatedSelectedItems, item)
     } else if (maxItems && updatedSelectedItems.length === maxItems) {
       if (maxItems === 1) {
-        updatedSelectedItems = [id]
+        updatedSelectedItems = [item]
       } else {
         return
       }
     } else {
-      updatedSelectedItems = [...updatedSelectedItems, id]
+      updatedSelectedItems = [...updatedSelectedItems, item]
     }
     setSelectedItems(updatedSelectedItems)
   }

--- a/src/common/hooks/useArrayStateManager.js
+++ b/src/common/hooks/useArrayStateManager.js
@@ -4,23 +4,26 @@ import PropTypes from 'prop-types'
 function useArrayStateManager({ maxItems }) {
   const [selectedItems, setSelectedItems] = useState([])
 
-  const removeItem = (array, item) =>
-    array.filter((elem) => elem !== item && elem?.id !== item?.id)
+  const removeItemFromArray = (array, item) =>
+    [...array].filter((elem) => elem !== item && elem?.id !== item?.id)
 
-  const handleSelectAdditionalItems = (item) => {
-    let updatedSelectedItems = [...selectedItems]
-    if (selectedItems.some((elem) => elem === item || elem?.id === item?.id)) {
-      updatedSelectedItems = removeItem(updatedSelectedItems, item)
-    } else if (maxItems && updatedSelectedItems.length === maxItems) {
-      if (maxItems === 1) {
-        updatedSelectedItems = [item]
-      } else {
-        return
-      }
-    } else {
-      updatedSelectedItems = [...updatedSelectedItems, item]
+  const hasItem = (array, item) =>
+    array.some((elem) => elem === item || elem?.id === item?.id)
+
+  const handleSelectAdditionalItems = (selectedItem) => {
+    if (maxItems === 1) {
+      setSelectedItems([selectedItem])
+      return
     }
-    setSelectedItems(updatedSelectedItems)
+
+    if (maxItems && selectedItems.length === maxItems) return
+
+    if (hasItem) {
+      setSelectedItems(removeItemFromArray(selectedItems, selectedItem))
+      return
+    }
+
+    setSelectedItems([...selectedItems, selectedItem])
   }
 
   return {

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -76,13 +76,13 @@ export const selectOneMediaDataHelper = (imageObj, videoObj) => {
   // allow for either image or video
   if (imageObj?.id) {
     return {
-      id: imageObj?.id,
+      ...imageObj,
       type: IMAGE,
     }
   }
   if (videoObj?.id) {
     return {
-      id: videoObj?.id,
+      ...videoObj,
       type: VIDEO,
     }
   }

--- a/src/components/CharacterCrud/CharacterCrudPresentation.js
+++ b/src/components/CharacterCrud/CharacterCrudPresentation.js
@@ -11,8 +11,8 @@ import useEditForm from 'common/hooks/useEditForm'
 function CharacterCrudPresentation({ backHandler, dataToEdit, submitHandler }) {
   const validator = yup.object().shape({
     relatedAudio: definitions.idArray(),
-    relatedImages: definitions.idArray(),
-    relatedVideos: definitions.idArray(),
+    relatedImages: definitions.objectArray(),
+    relatedVideos: definitions.objectArray(),
     relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     relatedDictionaryEntries: definitions.objectArray(),
     generalNote: definitions.paragraph({ charCount: 120 }),

--- a/src/components/DashboardJoinCard/DashboardJoinCardPresentation.js
+++ b/src/components/DashboardJoinCard/DashboardJoinCardPresentation.js
@@ -65,7 +65,7 @@ function DashboardJoinCardPresentation({
               </label>
               <select
                 id="role-to-assign"
-                name="role-to-assign"
+                data-testid="role-to-assign"
                 onChange={(e) =>
                   setSelectedRole(e.target.value.split(' ').join('_'))
                 }
@@ -83,8 +83,8 @@ function DashboardJoinCardPresentation({
                 Approve and assign role
               </label>
               <button
+                id="approve-request"
                 data-testid="approve-request"
-                name="approve-request"
                 type="button"
                 onClick={() => handleApprove(selectedRole)}
                 className="btn-contained"
@@ -98,9 +98,9 @@ function DashboardJoinCardPresentation({
                 Ignore request
               </label>
               <button
-                type="button"
+                id="igore-request"
                 data-testid="igore-request"
-                name="igore-request"
+                type="button"
                 onClick={() => handleIgnore()}
                 className="btn-outlined text-secondary border-secondary"
               >

--- a/src/components/DashboardJoinCard/DashboardJoinCardPresentation.js
+++ b/src/components/DashboardJoinCard/DashboardJoinCardPresentation.js
@@ -61,11 +61,11 @@ function DashboardJoinCardPresentation({
           <div className="lg:inline-flex justify-between w-full">
             <div className="lg:space-x-1 lg:inline-flex items-center">
               <label htmlFor="role-to-assign" className="sr-only">
-                Select message type
+                Select role to assign
               </label>
               <select
                 id="role-to-assign"
-                data-testid="role-to-assign"
+                data-testid="role-select"
                 onChange={(e) =>
                   setSelectedRole(e.target.value.split(' ').join('_'))
                 }
@@ -84,7 +84,7 @@ function DashboardJoinCardPresentation({
               </label>
               <button
                 id="approve-request"
-                data-testid="approve-request"
+                data-testid="approve-request-btn"
                 type="button"
                 onClick={() => handleApprove(selectedRole)}
                 className="btn-contained"
@@ -99,7 +99,7 @@ function DashboardJoinCardPresentation({
               </label>
               <button
                 id="igore-request"
-                data-testid="igore-request"
+                data-testid="igore-request-btn"
                 type="button"
                 onClick={() => handleIgnore()}
                 className="btn-outlined text-secondary border-secondary"

--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -38,8 +38,8 @@ function DictionaryCrudPresentation({
     pronunciations: definitions.textArray(),
     relatedAudio: definitions.idArray(),
     relatedEntries: definitions.objectArray(),
-    relatedImages: definitions.idArray(),
-    relatedVideos: definitions.idArray(),
+    relatedImages: definitions.objectArray(),
+    relatedVideos: definitions.objectArray(),
     relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     title: definitions
       .title({ charCount: 225 })

--- a/src/components/Form/HelpText.js
+++ b/src/components/Form/HelpText.js
@@ -6,16 +6,19 @@ import PropTypes from 'prop-types'
 function HelpText({ text }) {
   if (!text?.length > 0) return ''
   return (
-    <p data-testid="help-text" className="mt-2 text-sm text-fv-charcoal-light">
+    <div
+      data-testid="help-text"
+      className="mt-2 text-sm text-fv-charcoal-light"
+    >
       {text}
-    </p>
+    </div>
   )
 }
 
 // PROPTYPES
-const { string } = PropTypes
+const { node, oneOfType, string } = PropTypes
 HelpText.propTypes = {
-  text: string,
+  text: oneOfType([string, node]),
 }
 
 export default HelpText

--- a/src/components/Form/ImageArrayField.js
+++ b/src/components/Form/ImageArrayField.js
@@ -23,6 +23,7 @@ function ImageArrayField({
   const { fields, append, remove } = useFieldArray({
     control,
     name: nameId,
+    keyName: 'key', // https://github.com/react-hook-form/react-hook-form/issues/7562#issuecomment-1016379084
   })
   const { modalOpen, openModal, closeModal, selectItem } = useModalSelector(
     append,
@@ -37,7 +38,7 @@ function ImageArrayField({
           {fields?.length > 0 &&
             fields?.map((image, index) => (
               <div
-                key={image?.id}
+                key={image?.key}
                 className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1 mr-2 mb-2"
               >
                 <MediaThumbnail.Image

--- a/src/components/Form/ImageArrayField.js
+++ b/src/components/Form/ImageArrayField.js
@@ -1,9 +1,8 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
+import { useFieldArray } from 'react-hook-form'
 
 // FPCC
-import MediaThumbnail from 'components/MediaThumbnail'
-import useIdArrayField from 'common/hooks/useIdArrayField'
 import { useModalSelector } from 'common/hooks/useModalController'
 import AddImageModal from 'components/AddImageModal'
 import XButton from 'components/Form/XButton'
@@ -11,6 +10,8 @@ import FieldButton from 'components/Form/FieldButton'
 import ValidationError from 'components/Form/ValidationError'
 import HelpText from 'components/Form/HelpText'
 import FieldLabel from 'components/Form/FieldLabel'
+import { getMediaPath } from 'common/utils/mediaHelpers'
+import { IMAGE, THUMBNAIL } from 'common/constants'
 
 function ImageArrayField({
   label = '',
@@ -20,10 +21,13 @@ function ImageArrayField({
   maxItems = 3,
   errors,
 }) {
-  const { value, addItems, removeItem } = useIdArrayField(nameId, control)
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: nameId,
+  })
   const { modalOpen, openModal, closeModal, selectItem } = useModalSelector(
-    addItems,
-    removeItem,
+    append,
+    remove,
   )
 
   return (
@@ -31,29 +35,39 @@ function ImageArrayField({
       <FieldLabel nameId={nameId} text={label} />
       <div data-testid="ImageArrayField" className="space-y-2">
         <div>
-          {value?.length > 0 &&
-            value?.map((imageId) => (
+          {fields?.length > 0 &&
+            fields?.map((image) => (
               <div
-                key={`${imageId}`}
+                key={image?.id}
                 className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1 mr-2 mb-2"
               >
-                <MediaThumbnail.Image
-                  id={imageId}
-                  imageStyles="object-cover pointer-events-none"
-                />
+                <div
+                  id="MediaThumbnailImage"
+                  className="relative w-48 block aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden"
+                >
+                  <img
+                    src={getMediaPath({
+                      mediaObject: image,
+                      size: THUMBNAIL,
+                      type: IMAGE,
+                    })}
+                    alt={image?.title}
+                    className="object-cover pointer-events-none"
+                  />
+                </div>
 
-                <XButton onClickHandler={() => removeItem(imageId)} />
+                <XButton onClickHandler={() => remove(image)} />
               </div>
             ))}
         </div>
 
-        {value?.length >= maxItems ? (
+        {fields?.length >= maxItems ? (
           ''
         ) : (
           <div>
             <FieldButton label="Add image" onClickHandler={openModal} />
             <AddImageModal.Container
-              savedMedia={value}
+              savedMedia={fields}
               updateSavedMedia={selectItem}
               modalOpen={modalOpen}
               closeModal={closeModal}

--- a/src/components/Form/ImageArrayField.js
+++ b/src/components/Form/ImageArrayField.js
@@ -10,8 +10,7 @@ import FieldButton from 'components/Form/FieldButton'
 import ValidationError from 'components/Form/ValidationError'
 import HelpText from 'components/Form/HelpText'
 import FieldLabel from 'components/Form/FieldLabel'
-import { getMediaPath } from 'common/utils/mediaHelpers'
-import { IMAGE, THUMBNAIL } from 'common/constants'
+import MediaThumbnail from 'components/MediaThumbnail'
 
 function ImageArrayField({
   label = '',
@@ -41,20 +40,10 @@ function ImageArrayField({
                 key={image?.id}
                 className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1 mr-2 mb-2"
               >
-                <div
-                  id="MediaThumbnailImage"
-                  className="relative w-48 block aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden"
-                >
-                  <img
-                    src={getMediaPath({
-                      mediaObject: image,
-                      size: THUMBNAIL,
-                      type: IMAGE,
-                    })}
-                    alt={image?.title}
-                    className="object-cover pointer-events-none"
-                  />
-                </div>
+                <MediaThumbnail.Image
+                  imageObject={image}
+                  imageStyles="object-cover pointer-events-none"
+                />
 
                 <XButton onClickHandler={() => remove(image)} />
               </div>

--- a/src/components/Form/ImageArrayField.js
+++ b/src/components/Form/ImageArrayField.js
@@ -35,17 +35,17 @@ function ImageArrayField({
       <div data-testid="ImageArrayField" className="space-y-2">
         <div>
           {fields?.length > 0 &&
-            fields?.map((image) => (
+            fields?.map((image, index) => (
               <div
                 key={image?.id}
-                className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1 mr-2 mb-2"
+                className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1 mr-2 mb-2"
               >
                 <MediaThumbnail.Image
                   imageObject={image}
                   imageStyles="object-cover pointer-events-none"
                 />
 
-                <XButton onClickHandler={() => remove(image)} />
+                <XButton onClickHandler={() => remove(index)} />
               </div>
             ))}
         </div>

--- a/src/components/Form/ImageIdField.js
+++ b/src/components/Form/ImageIdField.js
@@ -35,8 +35,8 @@ function ImageIdFieldButton({ value, onChange }) {
   const [modalOpen, setModalOpen] = useState(false)
 
   const updateSavedMedia = (id) => {
-    if (isUUID(id[0])) {
-      onChange(id[0])
+    if (isUUID(id[0]?.id)) {
+      onChange(id[0]?.id)
     }
     setModalOpen(false)
   }
@@ -57,7 +57,7 @@ function ImageIdFieldButton({ value, onChange }) {
       />
       <AddImageModal.Container
         isDashboard
-        savedMedia={[value]}
+        savedMedia={[{ id: value }]}
         updateSavedMedia={updateSavedMedia}
         modalOpen={modalOpen}
         closeModal={() => setModalOpen(false)}

--- a/src/components/Form/SelectOneMedia.js
+++ b/src/components/Form/SelectOneMedia.js
@@ -15,11 +15,6 @@ import FieldButton from 'components/Form/FieldButton'
 import HelpText from 'components/Form/HelpText'
 import FieldLabel from 'components/Form/FieldLabel'
 
-const DEFAULT_MEDIA_VALUE = {
-  id: '',
-  type: '',
-}
-
 function SelectOneMedia({ label, nameId, control, errors, helpText }) {
   return (
     <div data-testid="SelectOneMedia">
@@ -27,7 +22,7 @@ function SelectOneMedia({ label, nameId, control, errors, helpText }) {
       <Controller
         id={nameId}
         name={nameId}
-        defaultValue={DEFAULT_MEDIA_VALUE}
+        defaultValue=""
         control={control}
         render={({ field: { value, onChange } }) => (
           <SelectOneButton value={value} onChange={onChange} />
@@ -50,14 +45,15 @@ function SelectOneButton({ value, onChange }) {
     // Clear out values
     if (value.id) {
       setType(null)
-      onChange(DEFAULT_MEDIA_VALUE)
+      onChange('')
     }
   }
 
-  const chooseMediaHandler = (id) => {
-    if (isUUID(id[0])) {
+  const chooseMediaHandler = (mediaArray) => {
+    const firstItem = mediaArray?.[0]
+    if (isUUID(firstItem?.id)) {
       const newMediaObj = {
-        id: id[0],
+        ...firstItem,
         type,
       }
       onChange(newMediaObj)

--- a/src/components/Form/SelectOneMedia.js
+++ b/src/components/Form/SelectOneMedia.js
@@ -71,11 +71,11 @@ function SelectOneButton({ value, onChange }) {
     <div className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1">
       {value.type === IMAGE ? (
         <MediaThumbnail.Image
-          id={value?.id}
+          imageObject={value}
           imageStyles="object-cover pointer-events-none"
         />
       ) : (
-        <MediaThumbnail.Video id={value?.id} />
+        <MediaThumbnail.Video videoObject={value} />
       )}
       <XButton onClickHandler={(event) => resetMedia(event)} />
     </div>

--- a/src/components/Form/SelectOneMedia.js
+++ b/src/components/Form/SelectOneMedia.js
@@ -22,7 +22,6 @@ function SelectOneMedia({ label, nameId, control, errors, helpText }) {
       <Controller
         id={nameId}
         name={nameId}
-        defaultValue=""
         control={control}
         render={({ field: { value, onChange } }) => (
           <SelectOneButton value={value} onChange={onChange} />

--- a/src/components/Form/SelectOneMedia.js
+++ b/src/components/Form/SelectOneMedia.js
@@ -45,7 +45,7 @@ function SelectOneButton({ value, onChange }) {
     // Clear out values
     if (value.id) {
       setType(null)
-      onChange('')
+      onChange(null)
     }
   }
 
@@ -119,7 +119,7 @@ function SelectOneButton({ value, onChange }) {
           updateSavedMedia={chooseMediaHandler}
           modalOpen={addMediaModalOpen}
           closeModal={() => setAddMediaModalOpen(false)}
-          maxFiles={1}
+          maxItems={1}
         />
       ) : (
         <AddVideoModal.Container
@@ -127,7 +127,7 @@ function SelectOneButton({ value, onChange }) {
           updateSavedMedia={chooseMediaHandler}
           modalOpen={addMediaModalOpen}
           closeModal={() => setAddMediaModalOpen(false)}
-          maxFiles={1}
+          maxItems={1}
         />
       )}
     </div>

--- a/src/components/Form/VideoArrayField.js
+++ b/src/components/Form/VideoArrayField.js
@@ -86,13 +86,13 @@ function VideoArrayField({
               Uploaded Videos
             </p>
             <div>
-              {fields?.map((video) => (
+              {fields?.map((video, index) => (
                 <div
                   key={video?.id}
-                  className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1 mr-2 mb-2"
+                  className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1 mr-2 mb-2"
                 >
                   <MediaThumbnail.Video videoObject={video} />
-                  <XButton onClickHandler={() => remove(video)} />
+                  <XButton onClickHandler={() => remove(index)} />
                 </div>
               ))}
             </div>

--- a/src/components/Form/VideoArrayField.js
+++ b/src/components/Form/VideoArrayField.js
@@ -4,8 +4,6 @@ import { useFieldArray } from 'react-hook-form'
 
 // FPCC
 import MediaThumbnail from 'components/MediaThumbnail'
-import { getMediaPath } from 'common/utils/mediaHelpers'
-import { VIDEO, ORIGINAL } from 'common/constants'
 import { useModalSelector } from 'common/hooks/useModalController'
 import AddVideoModal from 'components/AddVideoModal'
 import api from 'services/api'
@@ -93,19 +91,7 @@ function VideoArrayField({
                   key={video?.id}
                   className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 space-x-1 mr-2 mb-2"
                 >
-                  <div className="block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
-                    <video
-                      className="'object-cover pointer-events-none'"
-                      src={getMediaPath({
-                        mediaObject: video,
-                        size: ORIGINAL,
-                        type: VIDEO,
-                      })}
-                      disableRemotePlayback
-                    >
-                      Your browser does not support the video tag.
-                    </video>
-                  </div>
+                  <MediaThumbnail.Video videoObject={video} />
                   <XButton onClickHandler={() => remove(video)} />
                 </div>
               ))}

--- a/src/components/Form/VideoArrayField.js
+++ b/src/components/Form/VideoArrayField.js
@@ -24,6 +24,7 @@ function VideoArrayField({
   const { fields, append, remove } = useFieldArray({
     control,
     name: nameId,
+    keyName: 'key', // https://github.com/react-hook-form/react-hook-form/issues/7562#issuecomment-1016379084
   })
   const { modalOpen, openModal, closeModal, selectItem } = useModalSelector(
     append,
@@ -88,7 +89,7 @@ function VideoArrayField({
             <div>
               {fields?.map((video, index) => (
                 <div
-                  key={video?.id}
+                  key={video?.key}
                   className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1 mr-2 mb-2"
                 >
                   <MediaThumbnail.Video videoObject={video} />

--- a/src/components/GalleryCrud/GalleryCrudPresentation.js
+++ b/src/components/GalleryCrud/GalleryCrudPresentation.js
@@ -21,8 +21,8 @@ function GalleryCrudPresentation({
     titleTranslation: definitions.title({ charCount: 150 }),
     intro: definitions.paragraph(),
     introTranslation: definitions.paragraph(),
-    galleryItems: definitions.idArray(),
-    coverImage: definitions.uuid(),
+    galleryItems: definitions.objectArray(),
+    coverImage: definitions.objectArray(),
   })
 
   const defaultValues = {
@@ -91,11 +91,12 @@ function GalleryCrudPresentation({
             />
           </div>
           <div className="col-span-6">
-            <Form.ImageIdField
+            <Form.ImageArrayField
               label="Cover image"
               nameId="coverImage"
               control={control}
               errors={errors}
+              maxItems={1}
             />
           </div>
           <div className="col-span-12">

--- a/src/components/HomeCrud/HomeForm.js
+++ b/src/components/HomeCrud/HomeForm.js
@@ -9,15 +9,12 @@ import useEditForm from 'common/hooks/useEditForm'
 
 function HomeForm({ cancelHandler, dataToEdit, submitHandler }) {
   const validator = yup.object().shape({
-    logoId: definitions.uuid(),
+    logoArray: definitions.objectArray(),
   })
 
   const defaultValues = {
-    logoId: '',
-    banner: {
-      id: '',
-      type: '',
-    },
+    logoArray: '',
+    banner: '',
   }
 
   const { control, errors, handleSubmit, reset } = useEditForm({
@@ -33,12 +30,13 @@ function HomeForm({ cancelHandler, dataToEdit, submitHandler }) {
         <form onReset={reset}>
           <div className="mt-6 grid grid-cols-12 gap-6">
             <div className="col-span-6">
-              <Form.ImageIdField
+              <Form.ImageArrayField
                 label="Add logo"
-                nameId="logoId"
+                nameId="logoArray"
                 control={control}
                 helpText="Recommended size: 512 x 512"
                 errors={errors}
+                maxItems={1}
               />
             </div>
             <div className="col-span-12 flex items-center justify-start">

--- a/src/components/HomeCrud/HomeForm.js
+++ b/src/components/HomeCrud/HomeForm.js
@@ -14,7 +14,7 @@ function HomeForm({ cancelHandler, dataToEdit, submitHandler }) {
 
   const defaultValues = {
     logoArray: '',
-    banner: '',
+    banner: null,
   }
 
   const { control, errors, handleSubmit, reset } = useEditForm({

--- a/src/components/MediaEdit/MediaEditPresentation.js
+++ b/src/components/MediaEdit/MediaEditPresentation.js
@@ -67,7 +67,7 @@ function MediaEditPresentation({
               <AudioNative styling="mt-4" audioObject={dataToEdit} />
             </div>
           ) : (
-            <div className="m-6 col-span-6 max-h-1/3-screen rounded-lg overflow-hidden">
+            <div className="m-6 col-span-6 overflow-hidden">
               {mediaType === IMAGE && (
                 <img
                   src={getMediaPath({
@@ -75,7 +75,7 @@ function MediaEditPresentation({
                     type: IMAGE,
                   })}
                   alt={dataToEdit?.title}
-                  className="object-contain w-full"
+                  className="object-contain w-full rounded-lg"
                 />
               )}
               {mediaType === VIDEO && (

--- a/src/components/MediaEdit/MediaEditPresentation.js
+++ b/src/components/MediaEdit/MediaEditPresentation.js
@@ -96,7 +96,7 @@ function MediaEditPresentation({
               mediaType === AUDIO ? 'col-span-12' : 'col-span-6'
             }`}
           >
-            <div className="col-span-12 sm:col-span-6">
+            <div className="col-span-12">
               <Form.TextField
                 label="Title"
                 nameId="title"

--- a/src/components/MediaThumbnail/ImageThumbnail.js
+++ b/src/components/MediaThumbnail/ImageThumbnail.js
@@ -7,39 +7,36 @@ import { useImageObject } from 'common/dataHooks/useMedia'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import { IMAGE, SMALL } from 'common/constants'
 
-function ImageThumbnail(props) {
-  const {
-    id,
-    size = SMALL,
-    alt,
-    containerStyles = 'relative w-48 block aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden',
-    imageStyles = 'w-full h-full object-contain',
-    ...other
-  } = props
-
+function ImageThumbnail({
+  id,
+  containerStyles = 'relative w-48 block aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden',
+  imageStyles = 'w-full h-full object-contain',
+  imageObject,
+  ...other
+}) {
   const { sitename } = useParams()
   const [src, setSrc] = useState()
 
-  const mediaObject = useImageObject({ sitename, id })
+  const fetchedImageObject = useImageObject({ sitename, id })
 
   useEffect(() => {
-    if (mediaObject?.original) {
+    if (imageObject || fetchedImageObject?.original) {
       const srcToUse = getMediaPath({
-        mediaObject,
-        size,
+        mediaObject: imageObject || fetchedImageObject,
+        size: SMALL,
         type: IMAGE,
       })
       if (srcToUse !== src) {
         setSrc(srcToUse)
       }
     }
-  }, [src, setSrc, mediaObject, size])
+  }, [src, setSrc, fetchedImageObject, imageObject])
 
   return (
     <div id="MediaThumbnailImage" className={containerStyles}>
       <img
         src={src}
-        alt={alt || mediaObject?.title}
+        alt={imageObject?.title || fetchedImageObject?.title}
         className={imageStyles}
         {...other}
       />
@@ -48,13 +45,12 @@ function ImageThumbnail(props) {
 }
 
 // PROPTYPES
-const { string } = PropTypes
+const { object, string } = PropTypes
 ImageThumbnail.propTypes = {
   id: string,
-  size: string,
-  alt: string,
   containerStyles: string,
   imageStyles: string,
+  imageObject: object,
 }
 
 export default ImageThumbnail

--- a/src/components/MediaThumbnail/VideoThumbnail.js
+++ b/src/components/MediaThumbnail/VideoThumbnail.js
@@ -7,32 +7,29 @@ import { useVideoObject } from 'common/dataHooks/useMedia'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import { VIDEO, ORIGINAL } from 'common/constants'
 
-function VideoThumbnail(props) {
-  const {
-    id,
-    size = ORIGINAL,
-    alt,
-    containerStyles = 'block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden',
-    videoStyles = 'object-cover pointer-events-none',
-    ...other
-  } = props
-
+function VideoThumbnail({
+  id,
+  containerStyles = 'block relative w-48 aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden',
+  videoStyles = 'object-cover pointer-events-none',
+  videoObject,
+  ...other
+}) {
   const { sitename } = useParams()
   const [src, setSrc] = useState('')
 
   const mediaObject = useVideoObject({ sitename, id })
   useEffect(() => {
-    if (mediaObject?.original) {
+    if (videoObject || mediaObject?.original) {
       const srcToUse = getMediaPath({
-        mediaObject,
-        size,
+        mediaObject: videoObject || mediaObject,
+        size: ORIGINAL,
         type: VIDEO,
       })
       if (srcToUse !== src) {
         setSrc(srcToUse)
       }
     }
-  }, [src, setSrc, mediaObject, size])
+  }, [src, setSrc, mediaObject, videoObject])
 
   return (
     <div className={containerStyles}>
@@ -44,13 +41,12 @@ function VideoThumbnail(props) {
 }
 
 // PROPTYPES
-const { string } = PropTypes
+const { object, string } = PropTypes
 VideoThumbnail.propTypes = {
   id: string,
-  size: string,
-  alt: string,
   containerStyles: string,
   videoStyles: string,
+  videoObject: object,
 }
 
 export default VideoThumbnail

--- a/src/components/PageCrud/PageForm.js
+++ b/src/components/PageCrud/PageForm.js
@@ -23,10 +23,7 @@ function PageForm({ cancelHandler, dataToEdit, submitHandler, deleteHandler }) {
     bannerImage: '',
     bannerVideo: '',
     visibility: PUBLIC,
-    banner: {
-      id: '',
-      type: '',
-    },
+    banner: '',
   }
 
   const {

--- a/src/components/PageCrud/PageForm.js
+++ b/src/components/PageCrud/PageForm.js
@@ -23,7 +23,7 @@ function PageForm({ cancelHandler, dataToEdit, submitHandler, deleteHandler }) {
     bannerImage: '',
     bannerVideo: '',
     visibility: PUBLIC,
-    banner: '',
+    banner: null,
   }
 
   const {

--- a/src/components/SelectorImages/SelectorImagesContainer.js
+++ b/src/components/SelectorImages/SelectorImagesContainer.js
@@ -14,7 +14,7 @@ function SelectorImagesContainer({
   selectedMedia,
   mediaSelectHandler,
 }) {
-  const [searchSharedMedia, setSearchSharedMedia] = useState(false)
+  const [searchSharedMedia, setSearchSharedMedia] = useState('false')
 
   const {
     media,
@@ -25,14 +25,17 @@ function SelectorImagesContainer({
     isLoadingEntries,
     loadRef,
     loadLabel,
-  } = useMediaSearch({ type: TYPE_IMAGE, searchSharedMedia })
+  } = useMediaSearch({
+    type: TYPE_IMAGE,
+    searchSharedMedia: searchSharedMedia === 'true',
+  })
 
   const hasResults = !!(
     media?.pages !== undefined && media?.pages?.[0]?.results?.length > 0
   )
   const sharedMediaOptions = [
-    { value: true, label: 'Shared Images' },
-    { value: false, label: 'Your image library' },
+    { value: 'true', label: 'Shared Images' },
+    { value: 'false', label: 'Your image library' },
   ]
 
   return (

--- a/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
+++ b/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
@@ -27,7 +27,7 @@ function SelectorVisualMediaGridPresentation({
               <React.Fragment key={page?.pageNumber}>
                 {page.results.map((mediaObject) => {
                   if (
-                    savedMedia?.some((elemId) => elemId?.id === mediaObject?.id)
+                    savedMedia?.some((elem) => elem?.id === mediaObject?.id)
                   ) {
                     // If a media file is already attached to the document
                     // it will not be presented as a choice in the selectMedia dialog box

--- a/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
+++ b/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -14,17 +14,6 @@ function SelectorVisualMediaGridPresentation({
 }) {
   const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
 
-  const [hoverArray, setHoverArray] = useState([])
-
-  function handleHover(elementIndex, isLeaving) {
-    setHoverArray((previousArray) => {
-      if (isLeaving) {
-        return previousArray.filter((item) => item !== elementIndex)
-      }
-      return [...previousArray, elementIndex]
-    })
-  }
-
   return (
     <div
       data-testid="SelectorVisualMediaGridPresentation"
@@ -36,64 +25,56 @@ function SelectorVisualMediaGridPresentation({
             data?.pages?.[0]?.results?.length > 0 &&
             data?.pages?.map((page) => (
               <React.Fragment key={page?.pageNumber}>
-                {page.results.map((doc, elementIndex) => {
-                  if (savedMedia?.some((elemId) => elemId === doc?.id)) {
+                {page.results.map((mediaObject) => {
+                  if (
+                    savedMedia?.some((elemId) => elemId?.id === mediaObject?.id)
+                  ) {
                     // If a media file is already attached to the document
                     // it will not be presented as a choice in the selectMedia dialog box
                     return null
                   }
                   return (
-                    <li key={doc?.id} className="relative">
-                      <div className="focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-secondary group block w-full aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
+                    <li key={mediaObject?.id} className="relative group">
+                      <div className="focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-gray-100 focus-within:ring-secondary block w-full aspect-w-10 aspect-h-7 rounded-lg bg-gray-100 overflow-hidden">
                         <img
-                          src={doc?.thumbnail}
-                          alt={doc?.title}
+                          src={mediaObject?.thumbnail}
+                          alt={mediaObject?.title}
                           className="group-hover:opacity-75 object-cover pointer-events-none"
                         />
                         <button
                           data-testid="media-select-btn"
                           type="button"
                           className="absolute inset-0 focus:outline-none"
-                          onClick={() => mediaSelectHandler(doc?.id)}
-                          onMouseEnter={() => {
-                            handleHover(elementIndex, false)
-                          }}
-                          onMouseLeave={() => {
-                            handleHover(elementIndex, true)
-                          }}
+                          onClick={() => mediaSelectHandler(mediaObject)}
                         >
                           <span className="sr-only">
-                            View details for {doc?.title}
+                            View details for {mediaObject?.title}
                           </span>
                         </button>
                       </div>
                       <p className="mt-2 block text-sm font-medium text-fv-charcoal truncate pointer-events-none">
-                        {doc?.title}
+                        {mediaObject?.title}
                       </p>
-                      {doc?.width && doc?.height && (
-                        <p className="mt-2 block text-sm font-medium text-fv-charcoal-light truncate pointer-events-none">{`${doc?.width}x${doc?.height}`}</p>
+                      {mediaObject?.width && mediaObject?.height && (
+                        <p className="mt-2 block text-sm font-medium text-fv-charcoal-light truncate pointer-events-none">{`${mediaObject?.width}x${mediaObject?.height}`}</p>
                       )}
-                      {selectedMedia?.some((elemId) => elemId === doc?.id) && (
+                      {selectedMedia?.some(
+                        (elem) => elem?.id === mediaObject?.id,
+                      ) && (
                         <button
                           data-testid="media-select-btn"
                           type="button"
-                          onClick={() => mediaSelectHandler(doc?.id)}
-                          onMouseEnter={() => {
-                            handleHover(elementIndex, false)
-                          }}
-                          onMouseLeave={() => {
-                            handleHover(elementIndex, true)
-                          }}
+                          className="absolute top-0 right-0 h-8 w-8 rounded-full bg-white"
+                          onClick={() => mediaSelectHandler(mediaObject)}
                         >
-                          {hoverArray.includes(elementIndex)
-                            ? getIcon(
-                                'TimesCircleSolid',
-                                'absolute top-0 right-0 h-8 w-8 fill-red-700',
-                              )
-                            : getIcon(
-                                'CheckCircleSolid',
-                                'absolute top-0 right-0 h-8 w-8 fill-green-700',
-                              )}
+                          {getIcon(
+                            'TimesCircleSolid',
+                            'hidden group-hover:block h-8 w-8 fill-secondary',
+                          )}
+                          {getIcon(
+                            'CheckCircleSolid',
+                            'group-hover:hidden h-8 w-8 fill-bgGreen',
+                          )}
                         </button>
                       )}
                     </li>

--- a/src/components/SongCrud/SongCrudPresentation.js
+++ b/src/components/SongCrud/SongCrudPresentation.js
@@ -30,8 +30,8 @@ function SongCrudPresentation({
     acknowledgments: definitions.textArray({ charCount: 500 }),
     notes: definitions.textArray({ charCount: 500 }),
     relatedAudio: definitions.idArray(),
-    relatedImages: definitions.idArray(),
-    relatedVideos: definitions.idArray(),
+    relatedImages: definitions.objectArray(),
+    relatedVideos: definitions.objectArray(),
     relatedVideoLinks: definitions.relatedVideoUrlsArray(),
   })
 

--- a/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
+++ b/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
@@ -20,8 +20,8 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
     intro: definitions.wysiwyg({ charCount: 1200 }),
     introTranslation: definitions.wysiwyg({ charCount: 1200 }),
     relatedAudio: definitions.idArray(),
-    relatedImages: definitions.idArray(),
-    relatedVideos: definitions.idArray(),
+    relatedImages: definitions.objectArray(),
+    relatedVideos: definitions.objectArray(),
     relatedVideoLinks: definitions.relatedVideoUrlsArray(),
     acknowledgments: yup.array().of(yup.string()),
   })

--- a/src/components/StoryCrud/StoryCrudPreview.js
+++ b/src/components/StoryCrud/StoryCrudPreview.js
@@ -60,19 +60,19 @@ function StoryCrudPreview({ storyData }) {
     return (
       <>
         {images?.length > 0 &&
-          images?.map((imageId) => (
+          images?.map((image) => (
             <MediaThumbnail.Image
-              key={imageId}
-              id={imageId}
+              key={image?.id}
+              imageObject={image}
               containerStyles="w-40 h-40 mr-2"
               imageStyles="object-cover"
             />
           ))}
         {videos?.length > 0 &&
-          videos?.map((videoId) => (
+          videos?.map((video) => (
             <MediaThumbnail.Video
-              key={videoId}
-              id={videoId}
+              key={video?.id}
+              videoObject={video}
               containerStyles="w-40 h-40 mr-2"
             />
           ))}
@@ -144,7 +144,7 @@ function StoryCrudPreview({ storyData }) {
           )}
           <div className={detailStyle}>
             <h3 className={labelStyle}>Audio</h3>
-            {audioThumbnails(currentPage?.relatedAudio)}
+            {audioThumbnails(storyData?.relatedAudio)}
           </div>
           <div className={detailStyle}>
             <h3 className={labelStyle}>Visual media</h3>
@@ -196,6 +196,7 @@ function StoryCrudPreview({ storyData }) {
             {pages?.map((pageId, pageIndex) => (
               <button
                 type="button"
+                data-testid={`page-${pageIndex + 1}-btn`}
                 key={pageId}
                 onClick={() => setCurrentPage(pagesData?.[pageId])}
                 className={`cursor-pointer ${

--- a/src/components/StoryPagesCrud/StoryPageForm.js
+++ b/src/components/StoryPagesCrud/StoryPageForm.js
@@ -22,8 +22,8 @@ function StoryPageForm({
     textTranslation: definitions.wysiwyg({ charCount: 5000 }),
     notes: definitions.textArray({ charCount: 500 }),
     relatedAudio: definitions.idArray(),
-    relatedImages: definitions.idArray(),
-    relatedVideos: definitions.idArray(),
+    relatedImages: definitions.objectArray(),
+    relatedVideos: definitions.objectArray(),
     relatedVideoLinks: definitions.relatedVideoUrlsArray(),
   })
 

--- a/src/components/StoryPagesCrud/StoryPagesCrudPreview.js
+++ b/src/components/StoryPagesCrud/StoryPagesCrudPreview.js
@@ -7,15 +7,10 @@ import MediaThumbnail from 'components/MediaThumbnail'
 function StoryPagesCrudPreview({ page, pageNumber }) {
   const getVisualThumbnail = () => {
     if (page?.relatedImages?.length > 0) {
-      return (
-        <MediaThumbnail.Image
-          id={page?.relatedImages?.[0]}
-          imageStyles="object-cover rounded-md"
-        />
-      )
+      return <MediaThumbnail.Image imageObject={page?.relatedImages?.[0]} />
     }
     if (page?.relatedVideos?.length > 0) {
-      return <MediaThumbnail.Video id={page?.relatedVideos?.[0]} />
+      return <MediaThumbnail.Video videoObject={page?.relatedVideos?.[0]} />
     }
     if (page?.relatedVideoLinks?.length > 0) {
       return (
@@ -33,7 +28,7 @@ function StoryPagesCrudPreview({ page, pageNumber }) {
       className="w-full grid grid-cols-11 gap-8"
     >
       <div className="col-span-1">{pageNumber}</div>
-      <div className="col-span-4 h-48 overflow-hidden">
+      <div className="col-span-4 h-52 overflow-hidden">
         {getVisualThumbnail()}
       </div>
       <div className="col-span-5">


### PR DESCRIPTION
### Description of Changes

- Remove the need to fetch each image/video in separate api calls for thumbnails on edit forms. Achieved by maintaining media objects in state, as opposed to only ids.
- Single image fields (except widgets) switched over to use `ImageArrayField` with `maxItems={1}` by changing data adaptors

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
