### PR TITLE
Fw-6208, environment-aware apps pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "scripts": {
     "start": "webpack serve --env API_URL=http://localhost:8000/api/1.0/ --config webpack/webpack.development.js",
-    "startDev": "webpack serve --env API_URL=https://api.dev.firstvoices.com/api/1.0/ --config webpack/webpack.development.js",
-    "startPreprod": "webpack serve --env API_URL=https://api.preprod.firstvoices.com/api/1.0/ --config webpack/webpack.development.js",
+    "startDev": "webpack serve --env APP_ENV=dev API_URL=https://api.dev.firstvoices.com/api/1.0/ --config webpack/webpack.development.js",
+    "startPreprod": "webpack serve --env APP_ENV=preprod API_URL=https://api.preprod.firstvoices.com/api/1.0/ --config webpack/webpack.development.js",
     "startInSkaffold": "webpack serve --progress --config webpack/webpack.skaffold.js --disable-host-check",
     "build:production": "webpack --color --progress --config webpack/webpack.production.js",
     "prepare": "husky",

--- a/src/common/icons/Download.js
+++ b/src/common/icons/Download.js
@@ -12,7 +12,7 @@ function Download({ styling }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 100 100"
+      viewBox="3 0 106 100"
       className={styling}
     >
       <title>Download</title>

--- a/src/common/utils/getAppUrl.js
+++ b/src/common/utils/getAppUrl.js
@@ -7,10 +7,15 @@ function getAppUrl({ slug }) {
     : `https://${slug}.${GlobalConfiguration.ENV_APP}.firstvoicesapp.com`
 }
 
+function getAppLogoUrl({ slug }) {
+  const appUrl = getAppUrl({ slug })
+  return `${appUrl}/assets/${slug}/logo192.png`
+}
+
 const { string } = PropTypes
 
 getAppUrl.propTypes = {
   slug: string,
 }
 
-export default getAppUrl
+export { getAppUrl, getAppLogoUrl }

--- a/src/common/utils/getAppUrl.js
+++ b/src/common/utils/getAppUrl.js
@@ -1,0 +1,16 @@
+import GlobalConfiguration from 'src/GlobalConfiguration'
+import PropTypes from 'prop-types'
+
+function getAppUrl({ slug }) {
+  return GlobalConfiguration.ENV_APP === 'production'
+    ? `https://${slug}.firstvoicesapp.com`
+    : `https://${slug}.${GlobalConfiguration.ENV_APP}.firstvoicesapp.com`
+}
+
+const { string } = PropTypes
+
+getAppUrl.propTypes = {
+  slug: string,
+}
+
+export default getAppUrl

--- a/src/components/FVApps/FVAppsData.js
+++ b/src/components/FVApps/FVAppsData.js
@@ -9,6 +9,9 @@ function FVAppsData() {
     )
   }
 
+  // NOTE: this only gets the first page of sites,
+  // which won't work on dev but currently does work on prod
+  // See: FW-6216
   const sitesWithApps = sites?.data?.results?.filter(features)
 
   return {

--- a/src/components/FVApps/FVAppsPresentation.js
+++ b/src/components/FVApps/FVAppsPresentation.js
@@ -5,7 +5,7 @@ import { PropTypes } from 'prop-types'
 import SectionTitle from 'components/SectionTitle'
 import LogoPresentation from 'components/SiteLogo/LogoPresentation'
 import getIcon from 'common/utils/getIcon'
-import getAppUrl from 'common/utils/getAppUrl'
+import { getAppUrl, getAppLogoUrl } from 'common/utils/getAppUrl'
 
 function FVAppsPresentation({ sitesWithApps }) {
   const headerStyle = 'text-xl font-bold mb-1 mt-4'
@@ -36,7 +36,7 @@ function FVAppsPresentation({ sitesWithApps }) {
             <div className="grid grid-cols-3 gap-6 pt-8">
               {sitesWithApps?.map(({ id, title, slug }) => {
                 const appUrl = getAppUrl({ slug })
-                const appLogoSrc = `${appUrl}/${slug}/logo192.png`
+                const appLogoSrc = getAppLogoUrl({ slug })
 
                 return (
                   <div

--- a/src/components/FVApps/FVAppsPresentation.js
+++ b/src/components/FVApps/FVAppsPresentation.js
@@ -3,10 +3,9 @@ import { PropTypes } from 'prop-types'
 
 // FPCC
 import SectionTitle from 'components/SectionTitle'
-import { SMALL } from 'common/constants'
-import SiteLogo from 'components/SiteLogo'
+import LogoPresentation from 'components/SiteLogo/LogoPresentation'
 import getIcon from 'common/utils/getIcon'
-import GlobalConfiguration from 'src/GlobalConfiguration'
+import getAppUrl from 'common/utils/getAppUrl'
 
 function FVAppsPresentation({ sitesWithApps }) {
   const headerStyle = 'text-xl font-bold mb-1 mt-4'
@@ -35,47 +34,48 @@ function FVAppsPresentation({ sitesWithApps }) {
           </p>
           {sitesWithApps && (
             <div className="grid grid-cols-3 gap-6 pt-8">
-              {sitesWithApps?.map(({ id, title, slug, logo }) => (
-                <div
-                  className="rounded-lg bg-white p-6 drop-shadow-md flex flex-col items-center"
-                  key={id}
-                >
-                  <div className="h-16 w-16 md:w-24 md:h-24">
-                    <SiteLogo.Presentation
-                      size={SMALL}
-                      logo={logo || null}
-                      additionalStyling="ring-1 ring-gray-200"
-                    />
-                  </div>
-                  <h2 className="font-bold p-4">{title}</h2>
-                  <div className="pb-6 w-2/3 flex justify-between">
-                    {getIcon('Mobile', 'w-6 h-6 fill-current mr-3 inline-flex')}
-                    {getIcon('Tablet', 'w-6 h-6 fill-current mr-3 inline-flex')}
-                    {getIcon('PC', 'w-6 h-6 fill-current mr-3 inline-flex')}
-                  </div>
-                  <a
-                    href={
-                      GlobalConfiguration.ENV_APP === 'production'
-                        ? `https://${slug}.firstvoicesapp.com`
-                        : `https://${slug}.${GlobalConfiguration.ENV_APP}.firstvoicesapp.com`
-                    }
-                    target="_blank"
-                    rel="noreferrer"
+              {sitesWithApps?.map(({ id, title, slug }) => {
+                const appUrl = getAppUrl({ slug })
+                const appLogoSrc = `${appUrl}/${slug}/logo192.png`
+
+                return (
+                  <div
+                    className="rounded-lg bg-white p-6 drop-shadow-md flex flex-col items-center"
+                    key={id}
                   >
-                    <button
-                      data-testid="DownloadAppButton"
-                      type="button"
-                      className="bg-buttonOrange text-white px-4 py-2 rounded-md mb-"
-                    >
+                    <LogoPresentation
+                      imgSrc={appLogoSrc}
+                      altText={`${title} Logo`}
+                      additionalStyling="h-16 w-16 md:h-24 md:w-24"
+                    />
+                    <h2 className="font-bold p-4">{title}</h2>
+                    <div className="pb-6 w-2/3 flex justify-between">
                       {getIcon(
-                        'Download',
+                        'Mobile',
                         'w-6 h-6 fill-current mr-3 inline-flex',
                       )}
-                      Download App
-                    </button>
-                  </a>
-                </div>
-              ))}
+                      {getIcon(
+                        'Tablet',
+                        'w-6 h-6 fill-current mr-3 inline-flex',
+                      )}
+                      {getIcon('PC', 'w-6 h-6 fill-current mr-3 inline-flex')}
+                    </div>
+                    <a href={appUrl} target="_blank" rel="noreferrer">
+                      <button
+                        data-testid="DownloadAppButton"
+                        type="button"
+                        className="bg-buttonOrange text-white px-4 py-2 rounded-md mb-"
+                      >
+                        {getIcon(
+                          'Download',
+                          'w-6 h-6 fill-current mr-3 inline-flex',
+                        )}
+                        Download App
+                      </button>
+                    </a>
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/components/FVApps/FVAppsPresentation.js
+++ b/src/components/FVApps/FVAppsPresentation.js
@@ -46,7 +46,7 @@ function FVAppsPresentation({ sitesWithApps }) {
                     <LogoPresentation
                       imgSrc={appLogoSrc}
                       altText={`${title} Logo`}
-                      additionalStyling="h-16 w-16 md:h-24 md:w-24"
+                      additionalStyling="h-16 w-16 md:h-24 md:w-24 border"
                     />
                     <h2 className="font-bold p-4">{title}</h2>
                     <div className="pb-6 w-2/3 flex justify-between">

--- a/src/components/FVApps/FVAppsPresentation.js
+++ b/src/components/FVApps/FVAppsPresentation.js
@@ -48,8 +48,7 @@ function FVAppsPresentation({ sitesWithApps }) {
                       altText={`${title} Logo`}
                       additionalStyling="h-16 w-16 md:h-24 md:w-24 border"
                     />
-                    <h2 className="font-bold p-4">{title}</h2>
-                    <div className="pb-6 w-2/3 flex justify-between">
+                    <div className="p-6 w-2/3 flex justify-between">
                       {getIcon(
                         'Mobile',
                         'w-6 h-6 fill-current mr-3 inline-flex',
@@ -64,13 +63,13 @@ function FVAppsPresentation({ sitesWithApps }) {
                       <button
                         data-testid="DownloadAppButton"
                         type="button"
-                        className="bg-buttonOrange text-white px-4 py-2 rounded-md mb-"
+                        className="bg-secondary text-white px-4 py-2 rounded-md mb-"
                       >
                         {getIcon(
                           'Download',
                           'w-6 h-6 fill-current mr-3 inline-flex',
                         )}
-                        Download App
+                        Install {title}
                       </button>
                     </a>
                   </div>

--- a/src/components/SiteLogo/LogoPresentation.js
+++ b/src/components/SiteLogo/LogoPresentation.js
@@ -2,8 +2,6 @@ import React, { useRef, useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 function LogoPresentation({ imgSrc, altText, additionalStyling = '' }) {
-  console.log('LogoPresentation: ', { imgSrc, altText, additionalStyling })
-
   const [loaded, setLoaded] = useState(false)
   const imgRef = useRef()
 
@@ -16,7 +14,7 @@ function LogoPresentation({ imgSrc, altText, additionalStyling = '' }) {
   return (
     <div
       data-testid="SiteLogoPresentation"
-      className={`relative overflow-hidden w-full aspect-w-1 aspect-h-1 rounded-full bg-gray-50 ${additionalStyling}`}
+      className={`relative overflow-hidden rounded-full bg-gray-50 ${additionalStyling}`}
     >
       <div style={{ paddingBottom: '100%' }} />
       <img

--- a/src/components/SiteLogo/LogoPresentation.js
+++ b/src/components/SiteLogo/LogoPresentation.js
@@ -1,0 +1,44 @@
+import React, { useRef, useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+
+function LogoPresentation({ imgSrc, altText, additionalStyling = '' }) {
+  console.log('LogoPresentation: ', { imgSrc, altText, additionalStyling })
+
+  const [loaded, setLoaded] = useState(false)
+  const imgRef = useRef()
+
+  useEffect(() => {
+    if (imgRef?.current?.complete) {
+      setLoaded(true)
+    }
+  }, [])
+
+  return (
+    <div
+      data-testid="SiteLogoPresentation"
+      className={`relative overflow-hidden w-full aspect-w-1 aspect-h-1 rounded-full bg-gray-50 ${additionalStyling}`}
+    >
+      <div style={{ paddingBottom: '100%' }} />
+      <img
+        loading="lazy"
+        src={imgSrc}
+        alt={altText}
+        ref={imgRef}
+        onLoad={() => setLoaded(true)}
+        className={`absolute w-full h-full top-0 bottom-0 left-0 right-0 object-cover object-center ${
+          loaded ? 'opacity-1' : 'opacity-0'
+        }`}
+      />
+    </div>
+  )
+}
+
+// PROPTYPES
+const { string } = PropTypes
+LogoPresentation.propTypes = {
+  imgSrc: string,
+  altText: string,
+  additionalStyling: string,
+}
+
+export default LogoPresentation

--- a/src/components/SiteLogo/SiteLogoPresentation.js
+++ b/src/components/SiteLogo/SiteLogoPresentation.js
@@ -1,8 +1,9 @@
-import React, { useRef, useEffect, useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { useParams } from 'react-router-dom'
 
 // FPCC
+import LogoPresentation from 'components/SiteLogo/LogoPresentation'
 import { useSiteStore } from 'context/SiteContext'
 import { IMAGE, MEDIUM, ORIGINAL, SMALL, THUMBNAIL } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
@@ -11,8 +12,6 @@ import placeholder from 'images/cover-thumbnail.png'
 function SiteLogoPresentation({ logo, size = SMALL, additionalStyling = '' }) {
   const { site } = useSiteStore()
   const { sitename } = useParams()
-  const [loaded, setLoaded] = useState(false)
-  const imgRef = useRef()
 
   const altText = `${site?.title} Logo`
 
@@ -33,32 +32,16 @@ function SiteLogoPresentation({ logo, size = SMALL, additionalStyling = '' }) {
         size,
       })
     }
+
     return placeholder
   }
 
-  useEffect(() => {
-    if (imgRef?.current?.complete) {
-      setLoaded(true)
-    }
-  }, [])
-
   return (
-    <div
-      data-testid="SiteLogoPresentation"
-      className={`relative overflow-hidden w-full aspect-w-1 aspect-h-1 rounded-full bg-gray-50 ${additionalStyling}`}
-    >
-      <div style={{ paddingBottom: '100%' }} />
-      <img
-        loading="lazy"
-        src={getLogoSrc()}
-        alt={altText}
-        ref={imgRef}
-        onLoad={() => setLoaded(true)}
-        className={`absolute w-full h-full top-0 bottom-0 left-0 right-0 object-cover object-center ${
-          loaded ? 'opacity-1' : 'opacity-0'
-        }`}
-      />
-    </div>
+    <LogoPresentation
+      imgSrc={getLogoSrc()}
+      altText={altText}
+      additionalStyling={additionalStyling}
+    />
   )
 }
 

--- a/src/components/WidgetApps/WidgetAppsPresentation.js
+++ b/src/components/WidgetApps/WidgetAppsPresentation.js
@@ -4,13 +4,13 @@ import React from 'react'
 import SectionTitle from 'components/SectionTitle'
 import { useSiteStore } from 'context/SiteContext'
 import getIcon from 'common/utils/getIcon'
-import getAppUrl from 'common/utils/getAppUrl'
+import { getAppUrl, getAppLogoUrl } from 'common/utils/getAppUrl'
 import LogoPresentation from 'components/SiteLogo/LogoPresentation'
 
 function WidgetAppsPresentation() {
   const { site } = useSiteStore()
   const appUrl = getAppUrl({ slug: site?.sitename })
-  const appLogoSrc = `${appUrl}/${site?.sitename}/logo192.png`
+  const appLogoSrc = getAppLogoUrl({ slug: site?.sitename })
 
   return (
     <section className="px-4 lg:px-0 py-3 lg:py-6 bg-white">

--- a/src/components/WidgetApps/WidgetAppsPresentation.js
+++ b/src/components/WidgetApps/WidgetAppsPresentation.js
@@ -4,18 +4,19 @@ import React from 'react'
 import SectionTitle from 'components/SectionTitle'
 import { useSiteStore } from 'context/SiteContext'
 import getIcon from 'common/utils/getIcon'
+import getAppUrl from 'common/utils/getAppUrl'
 
 function WidgetAppsPresentation() {
   const { site } = useSiteStore()
-  const appLogoSrc = `https://${site?.sitename}.firstvoicesapp.com/${site?.sitename}/logo192.png`
-  const pwaUrl = `https://${site?.sitename}.firstvoicesapp.com/`
+  const pwaUrl = getAppUrl({ slug: site?.sitename })
+  const appLogoSrc = `${pwaUrl}/${site?.sitename}/logo192.png`
 
   return (
     <section className="px-4 lg:px-0 py-3 lg:py-6 bg-white">
       <div className="mx-5 lg:mx-10 mb-4 md:mb-6 lg:mb-8 xl:mb-12">
         <SectionTitle.Presentation title="DOWNLOAD MOBILE APP" />
         <h2 className="text-center text-secondary text-sm md:text-base lg:text-2xl mt-2 md:mt-3.5 lg:mt-5">
-          {site?.title} Language
+          {site?.title}
         </h2>
       </div>
       <div className="grid grid-cols-7 gap-6 md:gap-4 mx-auto max-w-screen-lg">

--- a/src/components/WidgetApps/WidgetAppsPresentation.js
+++ b/src/components/WidgetApps/WidgetAppsPresentation.js
@@ -5,11 +5,12 @@ import SectionTitle from 'components/SectionTitle'
 import { useSiteStore } from 'context/SiteContext'
 import getIcon from 'common/utils/getIcon'
 import getAppUrl from 'common/utils/getAppUrl'
+import LogoPresentation from 'components/SiteLogo/LogoPresentation'
 
 function WidgetAppsPresentation() {
   const { site } = useSiteStore()
-  const pwaUrl = getAppUrl({ slug: site?.sitename })
-  const appLogoSrc = `${pwaUrl}/${site?.sitename}/logo192.png`
+  const appUrl = getAppUrl({ slug: site?.sitename })
+  const appLogoSrc = `${appUrl}/${site?.sitename}/logo192.png`
 
   return (
     <section className="px-4 lg:px-0 py-3 lg:py-6 bg-white">
@@ -56,7 +57,7 @@ function WidgetAppsPresentation() {
           <p>
             <a
               className="inline-url"
-              href={pwaUrl}
+              href={appUrl}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -78,15 +79,14 @@ function WidgetAppsPresentation() {
         </div>
         <div className="col-span-7 md:col-span-3">
           <div className="flex-col items-center justify-center space-y-6 md:space-y-20">
-            <img
-              className="h-44 w-44 rounded-lg mx-auto border"
-              src={appLogoSrc}
-              loading="lazy"
-              alt={`${site?.title} App Logo`}
+            <LogoPresentation
+              imgSrc={appLogoSrc}
+              altText={`${site?.title} Logo`}
+              additionalStyling="h-44 w-44 mx-auto border"
             />
             <div className="flex justify-center w-full">
               <a
-                href={pwaUrl}
+                href={appUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="w-80 btn-contained bg-secondary"

--- a/webpack/webpack.development.js
+++ b/webpack/webpack.development.js
@@ -13,8 +13,8 @@ module.exports = (env) => {
     ENV_API_URL: env?.API_URL
       ? JSON.stringify(env.API_URL)
       : JSON.stringify('/api/1.0/'),
-    ENV_APP_ENV: process.env.APP_ENV
-      ? JSON.stringify(process.env.APP_ENV)
+    ENV_APP_ENV: env?.APP_ENV
+      ? JSON.stringify(env.APP_ENV)
       : JSON.stringify(''),
     ENV_AWS_CLIENT_ID: process.env.AWS_CLIENT_ID
       ? JSON.stringify(process.env.AWS_CLIENT_ID)


### PR DESCRIPTION
### Description of Changes

* extracted a LogoPresentation component that shows an arbitrary image url and alt text
* updated the main /apps page to show the app logos using the new component
* updated the app widget to use the environment-specific app URLs and logos, and to use the new component
* bonus: tweaked the cropping on the download icon
* Note: I logged a separate issue to get all pages of the site list when displaying the list of apps (currently prod only has one page, but the next site we add will spill onto a second page)
* Note: the AWS permissions don't allow app logos to be viewed locally at the moment, just a heads up if you are testing this out before that gets resolved

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
