### PR TITLE
Wysiwyg add unstyled

### DIFF
--- a/src/components/Form/WysiwygControls/BlockStyleToolbar.js
+++ b/src/components/Form/WysiwygControls/BlockStyleToolbar.js
@@ -4,10 +4,12 @@ import { RichUtils } from 'draft-js'
 import 'draft-js/dist/Draft.css'
 
 // FPCC
-import WysiwygControls from 'components/Form/WysiwygControls'
+import Button from 'components/Form/WysiwygControls/Button'
+import HeaderSelect from 'components/Form/WysiwygControls/HeaderSelect'
 import getIcon from 'common/utils/getIcon'
 
 export const headerBlockTypes = [
+  { label: 'Normal', value: 'unstyled' },
   { label: 'Heading', value: 'header-two' },
   { label: 'Subheading', value: 'header-three' },
 ]
@@ -27,14 +29,14 @@ function BlockStyleToolbar({ editorState, onChange, toolbar }) {
   return (
     <span className="flex border-b border-charcoal-100 text-xl text-charcoal-700">
       {toolbar?.includes('HEADER') && (
-        <WysiwygControls.HeaderSelect
+        <HeaderSelect
           headerBlockTypes={headerBlockTypes}
           value={currentBlockType}
           handleSelectChange={toggleBlockType}
         />
       )}
       {toolbar?.includes('OL') && (
-        <WysiwygControls.Button
+        <Button
           onClickHandler={(event) =>
             toggleBlockType(event, 'ordered-list-item')
           }
@@ -43,7 +45,7 @@ function BlockStyleToolbar({ editorState, onChange, toolbar }) {
         />
       )}
       {toolbar?.includes('UL') && (
-        <WysiwygControls.Button
+        <Button
           onClickHandler={(event) =>
             toggleBlockType(event, 'unordered-list-item')
           }

--- a/src/components/Form/WysiwygControls/HeaderSelect.js
+++ b/src/components/Form/WysiwygControls/HeaderSelect.js
@@ -14,7 +14,6 @@ function HeaderSelect({ value, handleSelectChange, headerBlockTypes }) {
       onChange={onToggle}
       className="border-r border-charcoal-100 pl-3 pr-10 py-2 focus:outline-none focus:ring-scarlet-800 focus:border-scarlet-800 text-sm"
     >
-      <option value="">Normal</option>
       {headerBlockTypes.map((heading) => (
         <option key={heading.value} value={heading.value}>
           {heading.label}

--- a/src/components/Form/WysiwygControls/InlineStyleToolbar.js
+++ b/src/components/Form/WysiwygControls/InlineStyleToolbar.js
@@ -4,7 +4,7 @@ import { RichUtils } from 'draft-js'
 import 'draft-js/dist/Draft.css'
 
 // FPCC
-import WysiwygControls from 'components/Form/WysiwygControls'
+import Button from 'components/Form/WysiwygControls/Button'
 
 function InlineStyleToolbar({ editorState, onChange }) {
   const currentStyle = editorState.getCurrentInlineStyle()
@@ -16,12 +16,12 @@ function InlineStyleToolbar({ editorState, onChange }) {
 
   return (
     <span className="flex border-b border-charcoal-100 text-xl text-charcoal-700">
-      <WysiwygControls.Button
+      <Button
         onClickHandler={(event) => toggleInlineStyle(event, 'BOLD')}
         label={<span className="font-bold">B</span>}
         active={currentStyle.has('BOLD')}
       />
-      <WysiwygControls.Button
+      <Button
         onClickHandler={(event) => toggleInlineStyle(event, 'ITALIC')}
         label={<span className="italic">I</span>}
         active={currentStyle.has('ITALIC')}


### PR DESCRIPTION
### Description of Changes

Draft-js treats all unrecognized blocks as unstyled, however if we need to convert the draft-js data in the future having the  block "type" explicitly set to "unstyled" will be easier to handle.
This PR changes the value for "normal" block types to "unstyled", rather than an empty string.

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
