### PR TITLE
FW-6337 replace loading with loadorerror part 2

### DIFF
--- a/src/common/dataHooks/useInfiniteScroll.js
+++ b/src/common/dataHooks/useInfiniteScroll.js
@@ -49,13 +49,6 @@ function useInfiniteScroll({
     return 'End of results.'
   }
 
-  const infiniteScroll = {
-    fetchNextPage: infiniteQueryResponse?.fetchNextPage,
-    hasNextPage: infiniteQueryResponse?.hasNextPage,
-    isFetchingNextPage: infiniteQueryResponse?.isFetchingNextPage,
-    loadLabel: getLoadLabel(),
-  }
-
   const loadRef = useRef(null)
   useIntersectionObserver({
     target: loadRef,
@@ -65,7 +58,6 @@ function useInfiniteScroll({
 
   return {
     ...infiniteQueryResponse,
-    infiniteScroll,
     loadLabel: getLoadLabel(),
     loadRef,
     hasResults: Boolean(

--- a/src/common/dataHooks/useInfiniteScroll.js
+++ b/src/common/dataHooks/useInfiniteScroll.js
@@ -1,11 +1,8 @@
-import { useRef } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 
 // FPCC
-import useIntersectionObserver from 'common/hooks/useIntersectionObserver'
-
 /**
- * Calls API and provides results and infinite scroll info.
+ * Calls API and provides results - use in conjunction with components/InfiniteLoadBtn or useIntersectionObserver for  infinite scrolling.
  */
 function useInfiniteScroll({
   queryKey,
@@ -39,27 +36,8 @@ function useInfiniteScroll({
     }),
   })
 
-  const getLoadLabel = () => {
-    if (infiniteQueryResponse?.isFetchingNextPage) {
-      return 'Loading more...'
-    }
-    if (infiniteQueryResponse?.hasNextPage) {
-      return 'Load more'
-    }
-    return 'End of results.'
-  }
-
-  const loadRef = useRef(null)
-  useIntersectionObserver({
-    target: loadRef,
-    onIntersect: infiniteQueryResponse?.fetchNextPage,
-    enabled: infiniteQueryResponse?.hasNextPage,
-  })
-
   return {
     ...infiniteQueryResponse,
-    loadLabel: getLoadLabel(),
-    loadRef,
     hasResults: Boolean(
       infiniteQueryResponse?.data?.pages !== undefined &&
         infiniteQueryResponse?.data?.pages?.[0]?.results?.length > 0,

--- a/src/common/dataHooks/useInfiniteScroll.js
+++ b/src/common/dataHooks/useInfiniteScroll.js
@@ -28,7 +28,7 @@ function useInfiniteScroll({
   }
 
   // Fetch search results
-  const response = useInfiniteQuery({
+  const infiniteQueryResponse = useInfiniteQuery({
     queryKey,
     queryFn,
     enabled,
@@ -40,34 +40,38 @@ function useInfiniteScroll({
   })
 
   const getLoadLabel = () => {
-    if (response?.isFetchingNextPage) {
+    if (infiniteQueryResponse?.isFetchingNextPage) {
       return 'Loading more...'
     }
-    if (response?.hasNextPage) {
+    if (infiniteQueryResponse?.hasNextPage) {
       return 'Load more'
     }
     return 'End of results.'
   }
 
   const infiniteScroll = {
-    fetchNextPage: response?.fetchNextPage,
-    hasNextPage: response?.hasNextPage,
-    isFetchingNextPage: response?.isFetchingNextPage,
+    fetchNextPage: infiniteQueryResponse?.fetchNextPage,
+    hasNextPage: infiniteQueryResponse?.hasNextPage,
+    isFetchingNextPage: infiniteQueryResponse?.isFetchingNextPage,
     loadLabel: getLoadLabel(),
   }
 
   const loadRef = useRef(null)
   useIntersectionObserver({
     target: loadRef,
-    onIntersect: response?.fetchNextPage,
-    enabled: response?.hasNextPage,
+    onIntersect: infiniteQueryResponse?.fetchNextPage,
+    enabled: infiniteQueryResponse?.hasNextPage,
   })
 
   return {
-    ...response,
+    ...infiniteQueryResponse,
     infiniteScroll,
     loadLabel: getLoadLabel(),
     loadRef,
+    hasResults: Boolean(
+      infiniteQueryResponse?.data?.pages !== undefined &&
+        infiniteQueryResponse?.data?.pages?.[0]?.results?.length > 0,
+    ),
   }
 }
 

--- a/src/common/dataHooks/useMediaSearch.js
+++ b/src/common/dataHooks/useMediaSearch.js
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -8,62 +7,43 @@ import {
   IMAGE,
   VIDEO,
   TYPES,
-  HAS_SITE_FEATURE,
-  SHARED_MEDIA,
   SORT,
   SORT_CREATED_DESC,
 } from 'common/constants'
 import { getPathForMediaType } from 'common/utils/mediaHelpers'
 import useSearchLoader from 'common/dataHooks/useSearchLoader'
-import useSearchAllSitesLoader from 'common/dataHooks/useSearchAllSitesLoader'
+import useSearchTerm from 'common/hooks/useSearchTerm'
 
-function useMediaSearch({ type, searchSharedMedia }) {
-  const [searchParams, setSearchParams] = useSearchParams()
-
+function useMediaSearch({ type }) {
   const path = getPathForMediaType(type)
+  const [currentFile, setCurrentFile] = useState(null) // Used for the sidebar to display the current selected file
 
-  const searchParamsQuery = searchParams.get('q') || ''
-  const [currentFile, setCurrentFile] = useState() // Used for the sidebar to display the current selected file
-  const [searchTerm, setSearchTerm] = useState(searchParamsQuery)
-  const [searchInputValue, setSearchInputValue] = useState(searchParamsQuery)
+  const {
+    displayedSearchTerm,
+    handleSearchTermChange,
+    submittedSearchTerm,
+    setSubmittedSearchTerm,
+    searchTermInUrl,
+    setSearchTermInUrl,
+  } = useSearchTerm()
 
   const siteSearchParams = new URLSearchParams({
-    q: searchTerm,
+    q: submittedSearchTerm,
     [TYPES]: type,
-    [SORT]: searchTerm ? null : SORT_CREATED_DESC,
+    [SORT]: submittedSearchTerm ? null : SORT_CREATED_DESC,
   })
 
-  const sharedMediaSearchParams = new URLSearchParams({
-    q: searchTerm,
-    [TYPES]: type,
-    [SORT]: searchTerm ? null : SORT_CREATED_DESC,
-    [HAS_SITE_FEATURE]: SHARED_MEDIA,
+  const infiniteQueryResponse = useSearchLoader({
+    searchParams: siteSearchParams,
   })
-
-  // Fetch search results
-  const siteSearchResponse = useSearchLoader({ searchParams: siteSearchParams })
-  const sharedMediaSearchResponse = useSearchAllSitesLoader({
-    searchParams: sharedMediaSearchParams,
-    enabled: searchSharedMedia,
-  })
-
-  const infiniteQueryResponse = searchSharedMedia
-    ? sharedMediaSearchResponse
-    : siteSearchResponse
-
-  const handleTextFieldChange = (event) => {
-    event.preventDefault()
-    setSearchInputValue(event.target.value)
-  }
-
-  const handleSearchSubmit = (event) => {
-    event.preventDefault()
-    setSearchTerm(searchInputValue)
-  }
 
   const handleSearchSubmitWithUrlSync = (event) => {
-    handleSearchSubmit(event)
-    setSearchParams({ q: searchInputValue })
+    event.preventDefault()
+    setSubmittedSearchTerm(displayedSearchTerm)
+    setCurrentFile(null)
+    if (displayedSearchTerm !== searchTermInUrl) {
+      setSearchTermInUrl(displayedSearchTerm)
+    }
   }
 
   useEffect(() => {
@@ -75,10 +55,9 @@ function useMediaSearch({ type, searchSharedMedia }) {
 
   return {
     ...infiniteQueryResponse,
-    handleSearchSubmit,
+    displayedSearchTerm,
     handleSearchSubmitWithUrlSync,
-    handleTextFieldChange,
-    searchValue: searchInputValue,
+    handleSearchTermChange,
     currentFile,
     setCurrentFile,
     typePlural: path,

--- a/src/common/dataHooks/useMediaSearchModal.js
+++ b/src/common/dataHooks/useMediaSearchModal.js
@@ -15,7 +15,7 @@ import useSearchLoader from 'common/dataHooks/useSearchLoader'
 import useSearchAllSitesLoader from 'common/dataHooks/useSearchAllSitesLoader'
 import useSearchTerm from 'common/hooks/useSearchTerm'
 
-function useMediaSearch({ type, searchSharedMedia }) {
+function useMediaSearchModal({ type, searchSharedMedia }) {
   const {
     displayedSearchTerm,
     handleSearchTermChange,
@@ -62,9 +62,9 @@ function useMediaSearch({ type, searchSharedMedia }) {
 
 const { oneOf, bool } = PropTypes
 
-useMediaSearch.propTypes = {
+useMediaSearchModal.propTypes = {
   type: oneOf([AUDIO, IMAGE, VIDEO]).isRequired,
   searchSharedMedia: bool,
 }
 
-export default useMediaSearch
+export default useMediaSearchModal

--- a/src/common/dataHooks/useMediaSearchModal.js
+++ b/src/common/dataHooks/useMediaSearchModal.js
@@ -11,14 +11,11 @@ import {
   SORT,
   SORT_CREATED_DESC,
 } from 'common/constants'
-import { getPathForMediaType } from 'common/utils/mediaHelpers'
 import useSearchLoader from 'common/dataHooks/useSearchLoader'
 import useSearchAllSitesLoader from 'common/dataHooks/useSearchAllSitesLoader'
 import useSearchTerm from 'common/hooks/useSearchTerm'
 
 function useMediaSearch({ type, searchSharedMedia }) {
-  const path = getPathForMediaType(type)
-
   const {
     displayedSearchTerm,
     handleSearchTermChange,
@@ -60,7 +57,6 @@ function useMediaSearch({ type, searchSharedMedia }) {
     displayedSearchTerm,
     handleSearchSubmit,
     handleSearchTermChange,
-    typePlural: path,
   }
 }
 

--- a/src/common/dataHooks/useMediaSearchModal.js
+++ b/src/common/dataHooks/useMediaSearchModal.js
@@ -1,0 +1,74 @@
+import PropTypes from 'prop-types'
+
+// FPCC
+import {
+  AUDIO,
+  IMAGE,
+  VIDEO,
+  TYPES,
+  HAS_SITE_FEATURE,
+  SHARED_MEDIA,
+  SORT,
+  SORT_CREATED_DESC,
+} from 'common/constants'
+import { getPathForMediaType } from 'common/utils/mediaHelpers'
+import useSearchLoader from 'common/dataHooks/useSearchLoader'
+import useSearchAllSitesLoader from 'common/dataHooks/useSearchAllSitesLoader'
+import useSearchTerm from 'common/hooks/useSearchTerm'
+
+function useMediaSearch({ type, searchSharedMedia }) {
+  const path = getPathForMediaType(type)
+
+  const {
+    displayedSearchTerm,
+    handleSearchTermChange,
+    submittedSearchTerm,
+    setSubmittedSearchTerm,
+  } = useSearchTerm()
+
+  const siteSearchParams = new URLSearchParams({
+    q: submittedSearchTerm,
+    [TYPES]: type,
+    [SORT]: submittedSearchTerm ? null : SORT_CREATED_DESC,
+  })
+
+  const sharedMediaSearchParams = new URLSearchParams({
+    q: submittedSearchTerm,
+    [TYPES]: type,
+    [SORT]: submittedSearchTerm ? null : SORT_CREATED_DESC,
+    [HAS_SITE_FEATURE]: SHARED_MEDIA,
+  })
+
+  // Fetch search results
+  const siteSearchResponse = useSearchLoader({ searchParams: siteSearchParams })
+  const sharedMediaSearchResponse = useSearchAllSitesLoader({
+    searchParams: sharedMediaSearchParams,
+    enabled: searchSharedMedia,
+  })
+
+  const infiniteQueryResponse = searchSharedMedia
+    ? sharedMediaSearchResponse
+    : siteSearchResponse
+
+  const handleSearchSubmit = (event) => {
+    event.preventDefault()
+    setSubmittedSearchTerm(displayedSearchTerm)
+  }
+
+  return {
+    ...infiniteQueryResponse,
+    displayedSearchTerm,
+    handleSearchSubmit,
+    handleSearchTermChange,
+    typePlural: path,
+  }
+}
+
+const { oneOf, bool } = PropTypes
+
+useMediaSearch.propTypes = {
+  type: oneOf([AUDIO, IMAGE, VIDEO]).isRequired,
+  searchSharedMedia: bool,
+}
+
+export default useMediaSearch

--- a/src/common/dataHooks/useSongs.js
+++ b/src/common/dataHooks/useSongs.js
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 
 // FPCC
@@ -17,27 +17,22 @@ import {
 } from 'common/dataAdaptors/songAdaptors'
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
 import useAuthCheck from 'common/hooks/useAuthCheck'
+import useInfiniteScroll from 'common/dataHooks/useInfiniteScroll'
 
 export function useSongs() {
   const { sitename } = useParams()
 
-  const allSongsResponse = useInfiniteQuery({
+  const infiniteQueryResponse = useInfiniteScroll({
     queryKey: [SONGS, sitename],
     queryFn: ({ pageParam = 1 }) =>
       api.songs.getAll({
         sitename,
         pageParam,
       }),
-    enabled: !!sitename,
+    resultAdaptor: (result) => songForViewing({ item: result }),
   })
-  const formattedResponse = allSongsResponse?.data?.pages?.map((page) => ({
-    results: page?.results?.map((result) => songForViewing({ item: result })),
-  }))
 
-  return {
-    ...allSongsResponse,
-    data: formattedResponse,
-  }
+  return infiniteQueryResponse
 }
 
 export function useSong({ id, sitename, edit = false }) {

--- a/src/common/dataHooks/useStories.js
+++ b/src/common/dataHooks/useStories.js
@@ -13,21 +13,22 @@ import {
 import useMutationWithNotification from 'common/dataHooks/useMutationWithNotification'
 import { audienceForApi } from 'common/dataAdaptors/audienceAdaptors'
 import { visibilityAdaptor } from 'common/dataAdaptors/visibilityAdaptor'
+import useInfiniteScroll from 'common/dataHooks/useInfiniteScroll'
 
 export function useStories() {
   const { sitename } = useParams()
 
-  const response = useQuery({
+  const infiniteQueryResponse = useInfiniteScroll({
     queryKey: [STORIES, sitename],
-    queryFn: () => api.stories.getAll({ sitename }),
-    ...{ enabled: !!sitename },
+    queryFn: ({ pageParam = 1 }) =>
+      api.stories.getAll({
+        sitename,
+        pageParam,
+      }),
+    resultAdaptor: (result) => storySummaryAdaptor({ item: result }),
   })
 
-  const formatted = response?.data?.results?.map((item) =>
-    storySummaryAdaptor({ item }),
-  )
-
-  return { ...response, data: { ...response?.data, results: formatted } }
+  return infiniteQueryResponse
 }
 
 export function useStory({ id, sitename, edit = false }) {

--- a/src/common/hooks/useIntersectionObserver.js
+++ b/src/common/hooks/useIntersectionObserver.js
@@ -23,7 +23,7 @@ export default function useIntersectionObserver({
       threshold: 0.1,
     })
 
-    if (loadRef && loadRef?.current) {
+    if (loadRef?.current) {
       observer.observe(loadRef.current)
     }
 

--- a/src/common/hooks/useSearchModal.js
+++ b/src/common/hooks/useSearchModal.js
@@ -32,10 +32,9 @@ function useSearchModal({ types, visibility = '' }) {
     [DOMAIN]: DOMAIN_BOTH,
   })
 
-  const { data, infiniteScroll, loadRef, isInitialLoading, isError } =
-    useSearchLoader({
-      searchParams: _searchParams,
-    })
+  const infiniteQueryResponse = useSearchLoader({
+    searchParams: _searchParams,
+  })
 
   const handleSearchSubmit = (event) => {
     event.preventDefault()
@@ -43,16 +42,10 @@ function useSearchModal({ types, visibility = '' }) {
   }
 
   return {
+    ...infiniteQueryResponse,
     displayedSearchTerm,
     handleSearchTermChange,
     handleSearchSubmit,
-    searchResults: data,
-    hasResults:
-      data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0,
-    infiniteScroll,
-    isLoading: isInitialLoading || isError,
-    isLoadingEntries: isInitialLoading,
-    loadRef,
   }
 }
 

--- a/src/components/ByAlphabet/ByAlphabetContainer.js
+++ b/src/components/ByAlphabet/ByAlphabetContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import ByAlphabetPresentation from 'components/ByAlphabet/ByAlphabetPresentation'
+import ByAlphabetKids from 'components/ByAlphabet/ByAlphabetKids'
 import ByAlphabetData from 'components/ByAlphabet/ByAlphabetData'
 import LoadOrError from 'components/LoadOrError'
 import SiteDocHead from 'components/SiteDocHead'
@@ -13,7 +14,7 @@ function ByAlphabetContainer({ kids = null }) {
     currentCharacter,
     searchType,
     setSearchType,
-    entryLabel,
+    labels,
     searchInfiniteQueryResponse,
     selectedTab,
     sitename,
@@ -25,18 +26,27 @@ function ByAlphabetContainer({ kids = null }) {
         titleArray={[currentCharacter?.title, 'Dictionary']}
         description={`Dictionary entries that start with ${currentCharacter?.title}.`}
       />
-      <ByAlphabetPresentation
-        characters={characterQueryResponse?.data?.characters || []}
-        currentCharacter={currentCharacter}
-        searchType={searchType}
-        setSearchType={setSearchType}
-        entryLabel={entryLabel}
-        searchInfiniteQueryResponse={searchInfiniteQueryResponse}
-        kids={kids}
-        selectedTab={selectedTab}
-        sitename={sitename}
-        tabs={tabs}
-      />
+      {kids ? (
+        <ByAlphabetKids
+          characters={characterQueryResponse?.data?.characters || []}
+          currentCharacter={currentCharacter}
+          searchType={searchType}
+          searchInfiniteQueryResponse={searchInfiniteQueryResponse}
+          sitename={sitename}
+        />
+      ) : (
+        <ByAlphabetPresentation
+          characters={characterQueryResponse?.data?.characters || []}
+          currentCharacter={currentCharacter}
+          searchType={searchType}
+          setSearchType={setSearchType}
+          labels={labels}
+          searchInfiniteQueryResponse={searchInfiniteQueryResponse}
+          selectedTab={selectedTab}
+          sitename={sitename}
+          tabs={tabs}
+        />
+      )}
     </LoadOrError>
   )
 }

--- a/src/components/ByAlphabet/ByAlphabetData.js
+++ b/src/components/ByAlphabet/ByAlphabetData.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import useSearchLoader from 'common/dataHooks/useSearchLoader'
 import { useCharacters } from 'common/dataHooks/useCharacters'
 import useSearchType from 'common/hooks/useSearchType'
+import { getPresentationPropertiesForType } from 'common/utils/stringHelpers'
 import {
   CHAR,
   KIDS,
@@ -20,7 +21,7 @@ function ByAlphabetData({ kids = null }) {
 
   const urlSearchType = searchParams.get(TYPES) || TYPE_DICTIONARY
   const character = searchParams.get(CHAR)
-  const { searchType, setSearchTypeInUrl, getSearchTypeLabel } = useSearchType({
+  const { searchType, setSearchTypeInUrl } = useSearchType({
     initialSearchType: urlSearchType,
   })
 
@@ -60,7 +61,7 @@ function ByAlphabetData({ kids = null }) {
     currentCharacter,
     searchType,
     setSearchType: setSearchTypeInUrl,
-    entryLabel: getSearchTypeLabel({ searchType }),
+    labels: getPresentationPropertiesForType(searchType),
   }
 }
 

--- a/src/components/ByAlphabet/ByAlphabetFilters.js
+++ b/src/components/ByAlphabet/ByAlphabetFilters.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+
+// FPCC
+import AudioButton from 'components/AudioButton'
+import { CHAR, TYPES } from 'common/constants'
+
+function ByAlphabetFilters({
+  characters,
+  currentCharacter,
+  searchType,
+  kids,
+  sitename,
+}) {
+  return (
+    <div data-testid="ByAlphabetFilters">
+      <div className="hidden md:block xl:p-2">
+        <div
+          data-testid={`SearchFilter_${currentCharacter.id}`}
+          className="font-medium flex justify-center mx-auto p-2 xl:p-4 text-5xl xl:text-7xl text-blumine-800"
+        >
+          {currentCharacter.title}
+          {currentCharacter?.relatedAudio?.length > 0 && (
+            <div className="ml-2">
+              <AudioButton
+                audioArray={currentCharacter?.relatedAudio}
+                iconStyling="fill-current h-8 w-8"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="block md:p-3">
+        <div className="grid grid-cols-6 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 mx-auto md:pt-5 md:border-t-2 md:border-charcoal-200">
+          {characters?.map(({ title, id }) => (
+            <Link
+              data-testid={`SearchFilter_${currentCharacter.id}`}
+              className={`border col-span-1 font-medium inline-flex justify-center m-1 p-2 rounded-lg shadow text-3xl ${
+                currentCharacter?.id === id ? 'bg-blumine-800 text-white' : ''
+              }`}
+              key={id}
+              to={`/${sitename}/${
+                kids ? 'kids/' : ''
+              }alphabet/startsWith?${CHAR}=${title}&${TYPES}=${searchType}`}
+            >
+              {title}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+// PROPTYPES
+const { array, bool, object, string } = PropTypes
+ByAlphabetFilters.propTypes = {
+  characters: array,
+  currentCharacter: object,
+  searchType: string,
+  kids: bool,
+  sitename: string,
+}
+
+export default ByAlphabetFilters

--- a/src/components/ByAlphabet/ByAlphabetKids.js
+++ b/src/components/ByAlphabet/ByAlphabetKids.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+//
+import DictionaryGrid from 'components/DictionaryGrid'
+import { TYPE_DICTIONARY } from 'common/constants'
+import ByAlphabetFilters from 'components/ByAlphabet/ByAlphabetFilters'
+
+function ByAlphabetKids({
+  characters,
+  currentCharacter,
+  searchInfiniteQueryResponse,
+  searchType,
+  sitename,
+}) {
+  return (
+    <div data-testid="ByAlphabetKids" className="grid grid-cols-11 md:p-2">
+      <div className="col-span-11 md:col-span-4 xl:col-span-3 mt-2 md:mt-5 print:hidden">
+        <ByAlphabetFilters
+          currentCharacter={currentCharacter}
+          sitename={sitename}
+          characters={characters}
+          searchType={searchType}
+          kids
+        />
+      </div>
+      <div className="col-span-11 md:col-span-7 xl:col-span-8">
+        <div className="bg-charcoal-50 p-4">
+          <DictionaryGrid.Presentation
+            infiniteQueryResponse={searchInfiniteQueryResponse}
+            sitename={sitename}
+            showType={searchType === TYPE_DICTIONARY}
+            hasSideNav
+            kids
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+// PROPTYPES
+const { array, object, string } = PropTypes
+ByAlphabetKids.propTypes = {
+  characters: array,
+  currentCharacter: object,
+  searchInfiniteQueryResponse: object,
+  searchType: string,
+  sitename: string,
+}
+
+export default ByAlphabetKids

--- a/src/components/ByAlphabet/ByAlphabetPresentation.js
+++ b/src/components/ByAlphabet/ByAlphabetPresentation.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-router-dom'
 
 import DictionaryList from 'components/DictionaryList'
 import DictionaryGrid from 'components/DictionaryGrid'
-import AudioButton from 'components/AudioButton'
 import SearchTypeSelector from 'components/SearchTypeSelector'
-import getIcon from 'common/utils/getIcon'
-import { CHAR, TYPES, TYPE_DICTIONARY } from 'common/constants'
+
+import { TYPE_DICTIONARY } from 'common/constants'
+import ByAlphabetFilters from 'components/ByAlphabet/ByAlphabetFilters'
+import DictionaryLinks from 'components/DictionaryLinks'
 
 function ByAlphabetPresentation({
   characters,
@@ -15,172 +15,64 @@ function ByAlphabetPresentation({
   searchInfiniteQueryResponse,
   searchType,
   setSearchType,
-  entryLabel,
+  labels,
   kids,
   sitename,
 }) {
-  const getAlphabetList = () =>
-    characters.map(({ title, id }) => (
-      <Link
-        data-testid={`SearchFilter_${currentCharacter.id}`}
-        className={`border col-span-1 font-medium inline-flex justify-center m-1 p-2 rounded-lg shadow text-3xl ${
-          currentCharacter?.id === id ? 'bg-blumine-800 text-white' : ''
-        }`}
-        key={id}
-        to={`/${sitename}/${
-          kids ? 'kids/' : ''
-        }alphabet/startsWith?${CHAR}=${title}&${TYPES}=${searchType}`}
-      >
-        {title}
-      </Link>
-    ))
-
-  const getNoResultsMessage = () => {
-    let typeLabel = ''
-    switch (searchType) {
-      case 'WORD':
-        typeLabel = 'words'
-        break
-      case 'PHRASE':
-        typeLabel = 'phrases'
-        break
-      default:
-        typeLabel = 'entries'
-        break
-    }
-    return (
-      <>
-        There are currently no {typeLabel} beginning with{' '}
-        <span className="text-2xl font-bold">{currentCharacter.title}</span> on
-        this language site.
-      </>
-    )
-  }
   return (
-    <>
-      <span className="hidden text-4xl font-bold text-center print:block">
-        {currentCharacter.title}
-      </span>
-      <div className="grid grid-cols-11 md:p-2">
-        <div className="col-span-11 md:col-span-4 xl:col-span-3 mt-2 md:mt-5 print:hidden">
-          <div className="hidden md:block xl:p-2">
-            <div
-              data-testid={`SearchFilter_${currentCharacter.id}`}
-              className="font-medium flex justify-center mx-auto p-2 xl:p-4 text-5xl xl:text-7xl text-blumine-800"
-            >
-              {currentCharacter.title}
-              {currentCharacter?.relatedAudio?.length > 0 && (
-                <div className="ml-2">
-                  <AudioButton
-                    audioArray={currentCharacter?.relatedAudio}
-                    iconStyling="fill-current h-8 w-8"
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="block md:p-3">
-            <div className="grid grid-cols-6 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 mx-auto md:pt-5 md:border-t-2 md:border-charcoal-200">
-              {getAlphabetList()}
-            </div>
-          </div>
-          {kids ? null : (
-            <div className="hidden lg:block mt-5">
-              <h2 className="text-2xl font-medium ml-7 text-charcoal-900">
-                BROWSE BY:
-              </h2>
-              <ul className="list-none">
-                <li
-                  id="CategoryLink"
-                  className="inline-block md:block transition duration-500 ease-in-out md:my-3 md:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/categories?${TYPES}=${searchType}`}
-                  >
-                    {getIcon(
-                      'Categories',
-                      'inline-flex fill-current w-8 lg:mr-5',
-                    )}
-                    Categories
-                  </Link>
-                </li>
-                <li
-                  id="WordsLink"
-                  className="inline-block md:block transition duration-500 ease-in-out md:my-3 md:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/words`}
-                  >
-                    {getIcon('Word', 'inline-flex fill-current w-8 lg:mr-5')}
-                    Words
-                  </Link>
-                </li>
-                <li
-                  id="PhrasesLink"
-                  className="inline-block md:block transition duration-500 ease-in-out md:my-3 md:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/phrases`}
-                  >
-                    {getIcon(
-                      'Phrase',
-                      'inline-flex fill-current w-8 lg:mr-5 mb-2',
-                    )}
-                    Phrases
-                  </Link>
-                </li>
-              </ul>
-            </div>
-          )}
+    <div
+      data-testid="ByAlphabetPresentation"
+      className="grid grid-cols-11 md:p-2"
+    >
+      <div className="col-span-11 md:col-span-4 xl:col-span-3 mt-2 md:mt-5 print:hidden">
+        <ByAlphabetFilters
+          currentCharacter={currentCharacter}
+          sitename={sitename}
+          characters={characters}
+          searchType={searchType}
+          kids={kids}
+        />
+        <div className="hidden lg:block my-5">
+          <DictionaryLinks />
         </div>
-
-        {kids ? (
-          <div className="min-h-220 col-span-11 md:col-span-7 xl:col-span-8">
-            <div className="bg-charcoal-50 p-4 min-h-screen">
-              <DictionaryGrid.Presentation
-                infiniteQueryResponse={searchInfiniteQueryResponse}
-                sitename={sitename}
-                showType={searchType === TYPE_DICTIONARY}
-                hasSideNav
-                kids
-              />
-            </div>
-          </div>
-        ) : (
-          <div className="min-h-220 col-span-11 md:col-span-7 xl:col-span-8 border-l-2 border-charcoal-200 md:pl-3 xl:pl-6">
-            <div className="block py-4">
-              <div className="flex items-center border-b border-charcoal-100 px-3 pb-5 print:hidden">
-                <SearchTypeSelector.Container
-                  selectedSearchType={searchType}
-                  setSearchType={setSearchType}
-                  accentColor="blumine-800"
-                />
-              </div>
-              <div className="hidden md:block p-2 print:block">
-                <DictionaryList.Presentation
-                  infiniteQueryResponse={searchInfiniteQueryResponse}
-                  noResultsMessage={getNoResultsMessage()}
-                  sitename={sitename}
-                  entryLabel={entryLabel}
-                  showType
-                />
-              </div>
-              <div className="block md:hidden print:hidden">
-                <DictionaryGrid.Presentation
-                  infiniteQueryResponse={searchInfiniteQueryResponse}
-                  sitename={sitename}
-                  showType={searchType === TYPE_DICTIONARY}
-                />
-              </div>
-            </div>
-          </div>
-        )}
       </div>
-      <div ref={searchInfiniteQueryResponse?.loadRef} className="w-full h-5" />
-    </>
+
+      <div className="col-span-11 md:col-span-7 xl:col-span-8 border-l-2 border-charcoal-200 md:pl-3 xl:pl-6">
+        <div className="block py-4">
+          <div className="flex items-center border-b border-charcoal-100 px-3 pb-5 print:hidden">
+            <SearchTypeSelector.Container
+              selectedSearchType={searchType}
+              setSearchType={setSearchType}
+              accentColor="blumine-800"
+            />
+          </div>
+          <div className="hidden md:block p-2 print:block">
+            <DictionaryList.Presentation
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+              noResultsMessage={
+                <>
+                  There are currently no {labels?.lowercase} beginning with{' '}
+                  <span className="text-2xl font-bold">
+                    {currentCharacter.title}
+                  </span>{' '}
+                  on this language site.
+                </>
+              }
+              sitename={sitename}
+              entryLabel={labels?.singular}
+              showType
+            />
+          </div>
+          <div className="block md:hidden print:hidden">
+            <DictionaryGrid.Presentation
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+              sitename={sitename}
+              showType={searchType === TYPE_DICTIONARY}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }
 // PROPTYPES
@@ -191,7 +83,7 @@ ByAlphabetPresentation.propTypes = {
   searchInfiniteQueryResponse: object,
   searchType: string,
   setSearchType: func,
-  entryLabel: string,
+  labels: object,
   kids: bool,
   sitename: string,
 }

--- a/src/components/ByCategory/ByCategoryContainer.js
+++ b/src/components/ByCategory/ByCategoryContainer.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import ByCategoryPresentation from 'components/ByCategory/ByCategoryPresentation'
+import ByCategoryKids from 'components/ByCategory/ByCategoryKids'
 import ByCategoryData from 'components/ByCategory/ByCategoryData'
 import LoadOrError from 'components/LoadOrError'
 import SiteDocHead from 'components/SiteDocHead'
@@ -13,7 +14,7 @@ function ByCategoryContainer({ kids = null }) {
     currentParentCategory,
     searchType,
     setSearchType,
-    entryLabel,
+    labels,
     searchInfiniteQueryResponse,
     selectedTab,
     sitename,
@@ -22,19 +23,29 @@ function ByCategoryContainer({ kids = null }) {
   return (
     <LoadOrError queryResponse={categoriesQueryResponse}>
       <SiteDocHead titleArray={[currentCategory?.title, 'Category']} />
-      <ByCategoryPresentation
-        categories={categoriesQueryResponse?.data?.results || []}
-        currentCategory={currentCategory}
-        currentParentCategory={currentParentCategory}
-        searchInfiniteQueryResponse={searchInfiniteQueryResponse}
-        searchType={searchType}
-        setSearchType={setSearchType}
-        entryLabel={entryLabel}
-        kids={kids}
-        selectedTab={selectedTab}
-        sitename={sitename}
-        tabs={tabs}
-      />
+      {kids ? (
+        <ByCategoryKids
+          categories={categoriesQueryResponse?.data?.results || []}
+          currentCategory={currentCategory}
+          currentParentCategory={currentParentCategory}
+          searchInfiniteQueryResponse={searchInfiniteQueryResponse}
+          searchType={searchType}
+          sitename={sitename}
+        />
+      ) : (
+        <ByCategoryPresentation
+          categories={categoriesQueryResponse?.data?.results || []}
+          currentCategory={currentCategory}
+          currentParentCategory={currentParentCategory}
+          searchInfiniteQueryResponse={searchInfiniteQueryResponse}
+          searchType={searchType}
+          setSearchType={setSearchType}
+          labels={labels}
+          selectedTab={selectedTab}
+          sitename={sitename}
+          tabs={tabs}
+        />
+      )}
     </LoadOrError>
   )
 }

--- a/src/components/ByCategory/ByCategoryData.js
+++ b/src/components/ByCategory/ByCategoryData.js
@@ -7,12 +7,13 @@ import useSearchType from 'common/hooks/useSearchType'
 import useSearchLoader from 'common/dataHooks/useSearchLoader'
 import { useCategories } from 'common/dataHooks/useCategories'
 import { CATEGORY, KIDS, TYPES, TYPE_DICTIONARY } from 'common/constants'
+import { getPresentationPropertiesForType } from 'common/utils/stringHelpers'
 function ByCategoryData({ kids = null }) {
   const { sitename, categoryId } = useParams()
   const [searchParams] = useSearchParams()
 
   const urlSearchType = searchParams.get(TYPES) || TYPE_DICTIONARY
-  const { searchType, setSearchTypeInUrl, getSearchTypeLabel } = useSearchType({
+  const { searchType, setSearchTypeInUrl } = useSearchType({
     initialSearchType: urlSearchType,
   })
 
@@ -59,7 +60,7 @@ function ByCategoryData({ kids = null }) {
     currentParentCategory,
     searchType,
     setSearchType: setSearchTypeInUrl,
-    entryLabel: getSearchTypeLabel({ searchType }),
+    labels: getPresentationPropertiesForType(searchType),
   }
 }
 

--- a/src/components/ByCategory/ByCategoryFilters.js
+++ b/src/components/ByCategory/ByCategoryFilters.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+
+// FPCC
+import getCategoryIcon from 'common/utils/getCategoryIcon'
+import getIcon from 'common/utils/getIcon'
+
+function ByCategoryFilters({
+  categories,
+  currentCategory,
+  currentParentCategory,
+  searchType,
+  kids,
+  sitename,
+}) {
+  const getParentCategoriesList = () =>
+    categories.map((category) => (
+      <li
+        key={category.id}
+        id={`SearchFilter${category.id}`}
+        className="inline-block lg:block transition duration-500 ease-in-out lg:my-2 lg:mx-5 grow "
+      >
+        <Link
+          className="transition duration-500 ease-in-out flex items-center cursor-pointer rounded-lg text-charcoal-700"
+          to={`/${sitename}/${kids ? 'kids/' : ''}categories/${category.id}`}
+        >
+          {getCategoryIcon(
+            category.title,
+            'inline-flex p-2 rounded-lg fill-current h-10 w-14',
+          )}
+          <div className="inline-flex text-lg font-medium">
+            {category.title}
+          </div>
+        </Link>
+      </li>
+    ))
+
+  return (
+    <div data-testid="ByCategoryFilters">
+      <div className="inline-block lg:block lg:px-3 lg:pt-3 print:hidden">
+        <ul
+          className={`list-none m-2 px-2 lg:space-y-2 ${
+            currentCategory?.id === currentParentCategory?.id
+              ? 'border-l-4 md:border-l-0 lg:border-l-4 border-charcoal-700'
+              : ''
+          }`}
+        >
+          <li
+            key={currentParentCategory.id}
+            id={`SearchFilter${currentParentCategory.id}`}
+            className="inline-block md:inline-flex lg:block w-full md:w-auto lg:w-full transition duration-500 ease-in-out lg:my-2 grow"
+          >
+            <Link
+              className="transition duration-500 ease-in-out rounded-lg pr-4 flex items-center cursor-pointer text-charcoal-700 bg-charcoal-200"
+              to={`/${sitename}/${kids ? 'kids/' : ''}categories/${
+                currentParentCategory.id
+              }?docType=${searchType}`}
+            >
+              {getCategoryIcon(
+                currentParentCategory.title,
+                'inline-flex p-2 rounded-lg fill-current h-10 w-14',
+              )}
+              <div className="inline-flex text-lg font-medium">
+                {currentParentCategory.title}
+              </div>
+            </Link>
+          </li>
+          {currentParentCategory?.children?.length > 0
+            ? currentParentCategory?.children?.map((child) => (
+                <li
+                  key={child.id}
+                  id={`SearchFilter${child.id}`}
+                  className={`inline-block md:inline-flex lg:block w-full md:w-auto lg:w-full transition duration-500 ease-in-out lg:my-2 grow ${
+                    child.id === currentCategory.id
+                      ? 'border-l-4 md:border-l-0 lg:border-l-4 border-charcoal-700'
+                      : ''
+                  }`}
+                >
+                  <Link
+                    className={`transition duration-500 ease-in-out ml-4 lg:ml-8 pr-4 lg:px-0 rounded-lg flex items-center cursor-pointer text-charcoal-700 ${
+                      child.id === currentCategory.id ? 'bg-charcoal-200' : ''
+                    }`}
+                    to={`/${sitename}/${kids ? 'kids/' : ''}categories/${
+                      child.id
+                    }?docType=${searchType}`}
+                  >
+                    {getIcon(
+                      'Placeholder',
+                      'inline-flex p-2 rounded-lg fill-current h-10 w-0',
+                    )}
+                    <div className="inline-flex text-lg font-medium">
+                      {child.title}
+                    </div>
+                  </Link>
+                </li>
+              ))
+            : null}
+        </ul>
+      </div>
+      <div className="hidden lg:block lg:p-3">
+        <ul className="list-none m-2 pt-5 lg:space-y-4 border-t-2 border-charcoal-200">
+          {getParentCategoriesList()}
+        </ul>
+      </div>
+    </div>
+  )
+}
+// PROPTYPES
+const { array, bool, object, string } = PropTypes
+ByCategoryFilters.propTypes = {
+  categories: array,
+  currentCategory: object,
+  currentParentCategory: object,
+  searchType: string,
+  kids: bool,
+  sitename: string,
+}
+
+export default ByCategoryFilters

--- a/src/components/ByCategory/ByCategoryKids.js
+++ b/src/components/ByCategory/ByCategoryKids.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// FPCC
+import DictionaryGrid from 'components/DictionaryGrid'
+import { TYPE_DICTIONARY } from 'common/constants'
+import ByCategoryFilters from 'components/ByCategory/ByCategoryFilters'
+
+function ByCategoryKids({
+  categories,
+  currentCategory,
+  currentParentCategory,
+  searchInfiniteQueryResponse,
+  searchType,
+  sitename,
+}) {
+  return (
+    <div data-testid="ByCategoryKids">
+      <div className="grid grid-cols-11 lg:p-2">
+        <div className="col-span-11 lg:col-span-3 xl:col-span-2 mt-2 lg:mt-5">
+          <ByCategoryFilters
+            categories={categories}
+            currentCategory={currentCategory}
+            currentParentCategory={currentParentCategory}
+            searchType={searchType}
+            sitename={sitename}
+            kids
+          />
+        </div>
+        <div className="col-span-11 lg:col-span-8 xl:col-span-9">
+          <div className="bg-charcoal-50 p-4">
+            <DictionaryGrid.Presentation
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+              sitename={sitename}
+              showType={searchType === TYPE_DICTIONARY}
+              hasSideNav
+              kids
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+// PROPTYPES
+const { array, object, string } = PropTypes
+ByCategoryKids.propTypes = {
+  categories: array,
+  currentCategory: object,
+  currentParentCategory: object,
+  searchType: string,
+  searchInfiniteQueryResponse: object,
+  sitename: string,
+}
+
+export default ByCategoryKids

--- a/src/components/ByCategory/ByCategoryPresentation.js
+++ b/src/components/ByCategory/ByCategoryPresentation.js
@@ -1,14 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-router-dom'
 
 // FPCC
 import DictionaryList from 'components/DictionaryList'
 import DictionaryGrid from 'components/DictionaryGrid'
-import getCategoryIcon from 'common/utils/getCategoryIcon'
-import getIcon from 'common/utils/getIcon'
 import SearchTypeSelector from 'components/SearchTypeSelector'
-import { TYPE_DICTIONARY, TYPE_PHRASE, TYPE_WORD } from 'common/constants'
+import { TYPE_DICTIONARY } from 'common/constants'
+import DictionaryLinks from 'components/DictionaryLinks'
+import ByCategoryFilters from 'components/ByCategory/ByCategoryFilters'
 
 function ByCategoryPresentation({
   categories,
@@ -17,230 +16,75 @@ function ByCategoryPresentation({
   searchInfiniteQueryResponse,
   searchType,
   setSearchType,
-  entryLabel,
-  kids,
+  labels,
   sitename,
 }) {
-  const getParentCategoriesList = () =>
-    categories.map((category) => (
-      <li
-        key={category.id}
-        id={`SearchFilter${category.id}`}
-        className="inline-block lg:block transition duration-500 ease-in-out lg:my-2 lg:mx-5 grow "
-      >
-        <Link
-          className="transition duration-500 ease-in-out flex items-center cursor-pointer rounded-lg text-charcoal-700"
-          to={`/${sitename}/${kids ? 'kids/' : ''}categories/${category.id}`}
-        >
-          {getCategoryIcon(
-            category.title,
-            'inline-flex p-2 rounded-lg fill-current h-10 w-14',
-          )}
-          <div className="inline-flex text-lg font-medium">
-            {category.title}
-          </div>
-        </Link>
-      </li>
-    ))
-
-  const getNoResultsMessage = () => {
-    let typeLabel = ''
-    switch (searchType) {
-      case TYPE_WORD:
-        typeLabel = 'words'
-        break
-      case TYPE_PHRASE:
-        typeLabel = 'phrases'
-        break
-      default:
-        typeLabel = 'entries'
-        break
-    }
-    return <>No {typeLabel} have been added to this category yet!</>
-  }
-
   return (
-    <>
+    <div
+      data-testid="ByCategoryPresentation"
+      className="grid grid-cols-11 lg:p-2"
+    >
       <span className="hidden text-2xl font-bold text-center print:block">
         {currentCategory?.title}
       </span>
-      <div className="grid grid-cols-11 lg:p-2">
-        <div className="col-span-11 lg:col-span-3 xl:col-span-2 mt-2 lg:mt-5">
-          <div className="inline-block lg:block lg:px-3 lg:pt-3 print:hidden">
-            <ul
-              className={`list-none m-2 px-2 lg:space-y-2 ${
-                currentCategory?.id === currentParentCategory?.id
-                  ? 'border-l-4 md:border-l-0 lg:border-l-4 border-charcoal-700'
-                  : ''
-              }`}
-            >
-              <li
-                key={currentParentCategory.id}
-                id={`SearchFilter${currentParentCategory.id}`}
-                className="inline-block md:inline-flex lg:block w-full md:w-auto lg:w-full transition duration-500 ease-in-out lg:my-2 grow"
-              >
-                <Link
-                  className="transition duration-500 ease-in-out rounded-lg pr-4 flex items-center cursor-pointer text-charcoal-700 bg-charcoal-200"
-                  to={`/${sitename}/${kids ? 'kids/' : ''}categories/${
-                    currentParentCategory.id
-                  }?docType=${searchType}`}
-                >
-                  {getCategoryIcon(
-                    currentParentCategory.title,
-                    'inline-flex p-2 rounded-lg fill-current h-10 w-14',
-                  )}
-                  <div className="inline-flex text-lg font-medium">
-                    {currentParentCategory.title}
-                  </div>
-                </Link>
-              </li>
-              {currentParentCategory?.children?.length > 0
-                ? currentParentCategory?.children?.map((child) => (
-                    <li
-                      key={child.id}
-                      id={`SearchFilter${child.id}`}
-                      className={`inline-block md:inline-flex lg:block w-full md:w-auto lg:w-full transition duration-500 ease-in-out lg:my-2 grow ${
-                        child.id === currentCategory.id
-                          ? 'border-l-4 md:border-l-0 lg:border-l-4 border-charcoal-700'
-                          : ''
-                      }`}
-                    >
-                      <Link
-                        className={`transition duration-500 ease-in-out ml-4 lg:ml-8 pr-4 lg:px-0 rounded-lg flex items-center cursor-pointer text-charcoal-700 ${
-                          child.id === currentCategory.id
-                            ? 'bg-charcoal-200'
-                            : ''
-                        }`}
-                        to={`/${sitename}/${kids ? 'kids/' : ''}categories/${
-                          child.id
-                        }?docType=${searchType}`}
-                      >
-                        {getIcon(
-                          'Placeholder',
-                          'inline-flex p-2 rounded-lg fill-current h-10 w-0',
-                        )}
-                        <div className="inline-flex text-lg font-medium">
-                          {child.title}
-                        </div>
-                      </Link>
-                    </li>
-                  ))
-                : null}
-            </ul>
-          </div>
-          <div className="hidden lg:block lg:p-3">
-            <ul className="list-none m-2 pt-5 lg:space-y-4 border-t-2 border-charcoal-200">
-              {getParentCategoriesList()}
-            </ul>
-          </div>
-          {kids ? null : (
-            <div className="hidden lg:block mt-1 lg:mt-5">
-              <h2 className="text-2xl font-medium ml-7 text-charcoal-900">
-                BROWSE BY:
-              </h2>
-              <ul className="list-none">
-                <li
-                  id="CategoryLink"
-                  className="inline-block lg:block transition duration-500 ease-in-out lg:my-3 lg:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/alphabet`}
-                  >
-                    {getIcon(
-                      'Alphabet',
-                      'inline-flex fill-current w-8 lg:mr-5',
-                    )}
-                    Alphabet
-                  </Link>
-                </li>
-                <li
-                  id="WordsLink"
-                  className="inline-block lg:block transition duration-500 ease-in-out lg:my-3 lg:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/words`}
-                  >
-                    {getIcon('Word', 'inline-flex fill-current w-8 lg:mr-5')}
-                    Words
-                  </Link>
-                </li>
-                <li
-                  id="PhrasesLink"
-                  className="inline-block lg:block transition duration-500 ease-in-out lg:my-3 lg:ml-8"
-                >
-                  <Link
-                    className="transition duration-500 ease-in-out p-3 grow rounded-lg capitalize cursor-pointer text-xl text-charcoal-900"
-                    to={`/${sitename}/phrases`}
-                  >
-                    {getIcon(
-                      'Phrase',
-                      'inline-flex fill-current w-8 lg:mr-5 mb-2',
-                    )}
-                    Phrases
-                  </Link>
-                </li>
-              </ul>
-            </div>
-          )}
+      {/* Side/Nav */}
+      <section className="col-span-11 lg:col-span-3 xl:col-span-2 mt-2 lg:mt-5">
+        <ByCategoryFilters
+          categories={categories}
+          currentCategory={currentCategory}
+          currentParentCategory={currentParentCategory}
+          searchType={searchType}
+          sitename={sitename}
+        />
+        <div className="hidden lg:block my-5">
+          <DictionaryLinks />
         </div>
-        {kids ? (
-          <div className="col-span-11 lg:col-span-8 xl:col-span-9">
-            <div className="bg-charcoal-50 p-4">
-              <DictionaryGrid.Presentation
-                infiniteQueryResponse={searchInfiniteQueryResponse}
-                sitename={sitename}
-                showType={searchType === TYPE_DICTIONARY}
-                hasSideNav
-                kids
-              />
-            </div>
+      </section>
+      {/* Main List */}
+      <section className="col-span-11 lg:col-span-8 xl:col-span-9 border-l-2 border-charcoal-200 lg:pl-7">
+        <div className="block lg:py-4">
+          <div className="flex items-center md:border-b border-charcoal-100 px-3 md:pb-2 lg:pb-5 print:hidden">
+            <SearchTypeSelector.Container
+              selectedSearchType={searchType}
+              setSearchType={setSearchType}
+              accentColor="charcoal-700"
+            />
           </div>
-        ) : (
-          <div className="col-span-11 lg:col-span-8 xl:col-span-9 border-l-2 border-charcoal-200 lg:pl-7">
-            <div className="block lg:py-4">
-              <div className="flex items-center md:border-b border-charcoal-100 px-3 md:pb-2 lg:pb-5 print:hidden">
-                <SearchTypeSelector.Container
-                  selectedSearchType={searchType}
-                  setSearchType={setSearchType}
-                  accentColor="charcoal-700"
-                />
-              </div>
-              <div className="hidden md:block p-2 print:block">
-                <DictionaryList.Presentation
-                  infiniteQueryResponse={searchInfiniteQueryResponse}
-                  noResultsMessage={getNoResultsMessage()}
-                  sitename={sitename}
-                  entryLabel={entryLabel}
-                  showType
-                />
-              </div>
-              <div className="block md:hidden print:hidden">
-                <DictionaryGrid.Presentation
-                  infiniteQueryResponse={searchInfiniteQueryResponse}
-                  sitename={sitename}
-                  showType={searchType === TYPE_DICTIONARY}
-                />
-              </div>
-            </div>
+          <div className="hidden md:block p-2 print:block">
+            <DictionaryList.Presentation
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+              noResultsMessage={
+                <>
+                  No {labels?.lowercase} have been added to this category yet!
+                </>
+              }
+              sitename={sitename}
+              entryLabel={labels?.singular}
+              showType
+            />
           </div>
-        )}
-      </div>
-    </>
+          <div className="block md:hidden print:hidden">
+            <DictionaryGrid.Presentation
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+              sitename={sitename}
+              showType={searchType === TYPE_DICTIONARY}
+            />
+          </div>
+        </div>
+      </section>
+    </div>
   )
 }
 // PROPTYPES
-const { array, bool, func, object, string } = PropTypes
+const { array, func, object, string } = PropTypes
 ByCategoryPresentation.propTypes = {
   categories: array,
   currentCategory: object,
   currentParentCategory: object,
   searchType: string,
-  entryLabel: string,
+  labels: object,
   setSearchType: func,
   searchInfiniteQueryResponse: object,
-  kids: bool,
   sitename: string,
 }
 

--- a/src/components/ByCategory/ByCategoryPresentation.js
+++ b/src/components/ByCategory/ByCategoryPresentation.js
@@ -186,7 +186,7 @@ function ByCategoryPresentation({
           )}
         </div>
         {kids ? (
-          <div className="min-h-220 col-span-11 lg:col-span-8 xl:col-span-9">
+          <div className="col-span-11 lg:col-span-8 xl:col-span-9">
             <div className="bg-charcoal-50 p-4">
               <DictionaryGrid.Presentation
                 infiniteQueryResponse={searchInfiniteQueryResponse}
@@ -198,7 +198,7 @@ function ByCategoryPresentation({
             </div>
           </div>
         ) : (
-          <div className="min-h-220 col-span-11 lg:col-span-8 xl:col-span-9 border-l-2 border-charcoal-200 lg:pl-7">
+          <div className="col-span-11 lg:col-span-8 xl:col-span-9 border-l-2 border-charcoal-200 lg:pl-7">
             <div className="block lg:py-4">
               <div className="flex items-center md:border-b border-charcoal-100 px-3 md:pb-2 lg:pb-5 print:hidden">
                 <SearchTypeSelector.Container
@@ -227,7 +227,6 @@ function ByCategoryPresentation({
           </div>
         )}
       </div>
-      <div ref={searchInfiniteQueryResponse?.loadRef} className="w-full h-5" />
     </>
   )
 }

--- a/src/components/DashboardAlphabet/DashboardAlphabetContainer.js
+++ b/src/components/DashboardAlphabet/DashboardAlphabetContainer.js
@@ -1,31 +1,19 @@
 import React from 'react'
-import { Route, Routes } from 'react-router-dom'
 
 // FPCC
 import DashboardAlphabetData from 'components/DashboardAlphabet/DashboardAlphabetData'
 import DashboardAlphabetPresentation from 'components/DashboardAlphabet/DashboardAlphabetPresentation'
 
 function DashboardAlphabetContainer() {
-  const { characters, headerContent, isLoading, site, sitename, tileContent } =
+  const { queryResponse, headerContent, site, tileContent } =
     DashboardAlphabetData()
   return (
-    <div id="DashboardAlphabetContainer">
-      <Routes>
-        <Route
-          path=""
-          element={
-            <DashboardAlphabetPresentation
-              headerContent={headerContent}
-              tileContent={tileContent}
-              characters={characters}
-              isLoading={isLoading}
-              site={site}
-              sitename={sitename}
-            />
-          }
-        />
-      </Routes>
-    </div>
+    <DashboardAlphabetPresentation
+      queryResponse={queryResponse}
+      headerContent={headerContent}
+      tileContent={tileContent}
+      site={site}
+    />
   )
 }
 

--- a/src/components/DashboardAlphabet/DashboardAlphabetData.js
+++ b/src/components/DashboardAlphabet/DashboardAlphabetData.js
@@ -1,18 +1,12 @@
-import { useParams } from 'react-router-dom'
-
 // FPCC
 import { useSiteStore } from 'context/SiteContext'
 import { useCharacters } from 'common/dataHooks/useCharacters'
 
 function DashboardAlphabetData() {
   const { site } = useSiteStore()
-  const { sitename } = useParams()
 
   // Data fetch
-
-  const { isInitialLoading, data } = useCharacters()
-
-  const tileContent = []
+  const queryResponse = useCharacters()
 
   const headerContent = {
     title: 'Alphabet',
@@ -22,11 +16,9 @@ function DashboardAlphabetData() {
 
   return {
     headerContent,
-    isLoading: isInitialLoading,
+    queryResponse,
     site,
-    sitename,
-    tileContent,
-    characters: data?.characters || [],
+    tileContent: [],
   }
 }
 

--- a/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
+++ b/src/components/DashboardAlphabet/DashboardAlphabetPresentation.js
@@ -10,11 +10,9 @@ import { CHAR } from 'common/constants'
 
 function DashboardAlphabetPresentation({
   headerContent,
-  isLoading,
+  queryResponse,
   tileContent,
-  characters,
   site,
-  sitename,
 }) {
   const tableHeaderClass =
     'px-6 py-3 text-xs font-medium text-charcoal-900 uppercase tracking-wider'
@@ -32,7 +30,7 @@ function DashboardAlphabetPresentation({
         site={site}
       >
         <DashboardTable.Presentation
-          isLoading={isLoading}
+          queryResponse={queryResponse}
           title="Characters"
           tableHead={
             <tr>
@@ -57,7 +55,7 @@ function DashboardAlphabetPresentation({
               </th>
             </tr>
           }
-          tableBody={characters.map((character) => (
+          tableBody={queryResponse?.data?.characters?.map((character) => (
             <tr key={character.id}>
               <td className="px-6 py-4 whitespace-nowrap text-charcoal-900">
                 {character.title}
@@ -81,7 +79,7 @@ function DashboardAlphabetPresentation({
               </td>
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
-                  to={`/${sitename}/dashboard/edit/character?id=${character?.id}`}
+                  to={`/${site?.sitename}/dashboard/edit/character?id=${character?.id}`}
                   className="text-blumine-800 hover:text-blumine-900 flex items-center"
                 >
                   {getIcon('Pencil', 'fill-current w-6 h-6 mr-2')}
@@ -89,7 +87,7 @@ function DashboardAlphabetPresentation({
               </td>
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
-                  to={`/${sitename}/alphabet?${CHAR}=${character?.title}`}
+                  to={`/${site?.sitename}/alphabet?${CHAR}=${character?.title}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-blumine-800 hover:text-blumine-900 flex items-center"
@@ -105,13 +103,12 @@ function DashboardAlphabetPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, object, string } = PropTypes
+const { array, object } = PropTypes
 DashboardAlphabetPresentation.propTypes = {
-  characters: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
+
   site: object,
-  sitename: string,
   tileContent: array,
 }
 

--- a/src/components/DashboardCategories/DashboardCategoriesContainer.js
+++ b/src/components/DashboardCategories/DashboardCategoriesContainer.js
@@ -5,22 +5,14 @@ import DashboardCategoriesData from 'components/DashboardCategories/DashboardCat
 import DashboardCategoriesPresentation from 'components/DashboardCategories/DashboardCategoriesPresentation'
 
 function DashboardCategoriesContainer() {
-  const {
-    categories,
-    categoriesQueryResponse,
-    headerContent,
-    site,
-    sitename,
-    tileContent,
-  } = DashboardCategoriesData()
+  const { queryResponse, headerContent, site, tileContent } =
+    DashboardCategoriesData()
   return (
     <DashboardCategoriesPresentation
+      queryResponse={queryResponse}
       headerContent={headerContent}
       tileContent={tileContent}
-      categories={categories}
-      isLoading={categoriesQueryResponse?.isPending}
       site={site}
-      sitename={sitename}
     />
   )
 }

--- a/src/components/DashboardCategories/DashboardCategoriesData.js
+++ b/src/components/DashboardCategories/DashboardCategoriesData.js
@@ -11,7 +11,7 @@ function DashboardCategoriesData() {
 
   // Data fetch
 
-  const categoriesQueryResponse = useCategories()
+  const queryResponse = useCategories()
 
   const tileContent = [
     {
@@ -32,11 +32,9 @@ function DashboardCategoriesData() {
 
   return {
     headerContent,
-    categoriesQueryResponse,
+    queryResponse,
     site,
-    sitename,
     tileContent,
-    categories: categoriesQueryResponse?.allCategories || [],
   }
 }
 

--- a/src/components/DashboardCategories/DashboardCategoriesPresentation.js
+++ b/src/components/DashboardCategories/DashboardCategoriesPresentation.js
@@ -9,12 +9,10 @@ import getIcon from 'common/utils/getIcon'
 import { TYPE_DICTIONARY } from 'common/constants'
 
 function DashboardCategoriesPresentation({
+  queryResponse,
   headerContent,
-  isLoading,
   tileContent,
-  categories,
   site,
-  sitename,
 }) {
   const tableHeaderClass =
     'px-6 py-3 text-left text-xs font-medium text-charcoal-900 uppercase tracking-wider'
@@ -27,7 +25,7 @@ function DashboardCategoriesPresentation({
         site={site}
       >
         <DashboardTable.Presentation
-          isLoading={isLoading}
+          queryResponse={queryResponse}
           title="Categories"
           tableHead={
             <tr>
@@ -46,7 +44,7 @@ function DashboardCategoriesPresentation({
               </th>
             </tr>
           }
-          tableBody={categories.map((category) => (
+          tableBody={queryResponse?.allCategories?.map((category) => (
             <tr key={category.id}>
               <td className="px-6 py-4 whitespace-nowrap text-sm text-charcoal-900">
                 {category.title}
@@ -57,7 +55,7 @@ function DashboardCategoriesPresentation({
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
                   data-testid={`${category.title}-edit-link`}
-                  to={`/${sitename}/dashboard/edit/category?id=${category?.id}`}
+                  to={`/${site?.sitename}/dashboard/edit/category?id=${category?.id}`}
                   className="text-scarlet-800 hover:text-scarlet-900 flex items-center"
                 >
                   {getIcon('Pencil', 'fill-current w-6 h-6 mr-2')}
@@ -66,7 +64,7 @@ function DashboardCategoriesPresentation({
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
                   data-testid={`${category.title}-link`}
-                  to={`/${sitename}/categories/${category?.id}?type=${TYPE_DICTIONARY}`}
+                  to={`/${site?.sitename}/categories/${category?.id}?type=${TYPE_DICTIONARY}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-scarlet-800 hover:text-scarlet-900 flex items-center"
@@ -82,13 +80,11 @@ function DashboardCategoriesPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, object, string } = PropTypes
+const { array, object } = PropTypes
 DashboardCategoriesPresentation.propTypes = {
-  categories: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
   site: object,
-  sitename: string,
   tileContent: array,
 }
 

--- a/src/components/DashboardEntries/DashboardEntriesPresentation.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentation.js
@@ -63,17 +63,12 @@ function DashboardEntriesPresentation({
           />
         </section>
       )}
-      <section className="w-full">
-        <DashboardEntriesPresentationList
-          searchInfiniteQueryResponse={searchInfiniteQueryResponse}
-          emptyListMessage={emptyListMessage}
-          entryLabel={entryLabel}
-        />
-        <div
-          ref={searchInfiniteQueryResponse?.loadRef}
-          className="w-full h-10"
-        />
-      </section>
+
+      <DashboardEntriesPresentationList
+        searchInfiniteQueryResponse={searchInfiniteQueryResponse}
+        emptyListMessage={emptyListMessage}
+        entryLabel={entryLabel}
+      />
     </div>
   )
 }

--- a/src/components/DashboardEntries/DashboardEntriesPresentationList.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentationList.js
@@ -18,6 +18,7 @@ import {
   SORT_MODIFIED,
   SORT_MODIFIED_DESC,
 } from 'common/constants'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function DashboardEntriesPresentationList({
   searchInfiniteQueryResponse,
@@ -39,7 +40,7 @@ function DashboardEntriesPresentationList({
 
   return (
     <LoadOrError queryResponse={searchInfiniteQueryResponse}>
-      <div
+      <section
         data-testid="EntriesListPresentation"
         className="bg-white min-h-screen w-full rounded-lg overflow-hidden"
       >
@@ -200,22 +201,9 @@ function DashboardEntriesPresentationList({
                 </tbody>
               </table>
             </div>
-            <div className="p-3 text-center text-charcoal-900 font-medium print:hidden">
-              <button
-                data-testid="load-btn"
-                type="button"
-                className={
-                  !searchInfiniteQueryResponse?.hasNextPage ? 'cursor-text' : ''
-                }
-                onClick={() => searchInfiniteQueryResponse?.fetchNextPage()}
-                disabled={
-                  !searchInfiniteQueryResponse?.hasNextPage ||
-                  searchInfiniteQueryResponse?.isFetchingNextPage
-                }
-              >
-                {searchInfiniteQueryResponse?.loadLabel}
-              </button>
-            </div>
+            <InfiniteLoadBtn
+              infiniteQueryResponse={searchInfiniteQueryResponse}
+            />
           </div>
         ) : (
           <div className="w-full flex">
@@ -224,7 +212,7 @@ function DashboardEntriesPresentationList({
             </div>
           </div>
         )}
-      </div>
+      </section>
 
       <Drawer.Presentation
         isOpen={drawerOpen}

--- a/src/components/DashboardEntries/DashboardEntriesPresentationList.js
+++ b/src/components/DashboardEntries/DashboardEntriesPresentationList.js
@@ -44,8 +44,7 @@ function DashboardEntriesPresentationList({
         data-testid="EntriesListPresentation"
         className="bg-white min-h-screen w-full rounded-lg overflow-hidden"
       >
-        {searchInfiniteQueryResponse?.data?.pages !== undefined &&
-        searchInfiniteQueryResponse?.data?.pages?.[0]?.results?.length > 0 ? (
+        {searchInfiniteQueryResponse?.hasResults ? (
           <div className="flex flex-col w-full">
             <div className="border-b border-charcoal-200">
               <table className="table-auto w-full divide-y divide-charcoal-200">

--- a/src/components/DashboardImmersion/DashboardImmersionContainer.js
+++ b/src/components/DashboardImmersion/DashboardImmersionContainer.js
@@ -6,9 +6,9 @@ import DashboardImmersionPresentation from 'components/DashboardImmersion/Dashbo
 
 function DashboardImmersionContainer() {
   const {
-    labels,
+    queryResponse,
     headerContent,
-    isLoading,
+
     site,
     tileContent,
     submitHandler,
@@ -17,10 +17,9 @@ function DashboardImmersionContainer() {
   } = DashboardImmersionData()
   return (
     <DashboardImmersionPresentation
+      queryResponse={queryResponse}
       headerContent={headerContent}
       tileContent={tileContent}
-      labels={labels}
-      isLoading={isLoading}
       site={site}
       submitHandler={submitHandler}
       currentLabel={currentLabel}

--- a/src/components/DashboardImmersion/DashboardImmersionData.js
+++ b/src/components/DashboardImmersion/DashboardImmersionData.js
@@ -14,7 +14,7 @@ function DashboardImmersionData() {
 
   const [currentLabel, setCurrentLabel] = useState()
 
-  const { isInitialLoading, isFetching, labels } = useImmersionLabels()
+  const queryResponse = useImmersionLabels()
 
   const tileContent = []
 
@@ -41,10 +41,9 @@ function DashboardImmersionData() {
 
   return {
     headerContent,
-    isLoading: isInitialLoading || isFetching,
+    queryResponse,
     site,
     tileContent,
-    labels,
     submitHandler,
     currentLabel,
     setCurrentLabel,

--- a/src/components/DashboardImmersion/DashboardImmersionPresentation.js
+++ b/src/components/DashboardImmersion/DashboardImmersionPresentation.js
@@ -9,10 +9,9 @@ import getIcon from 'common/utils/getIcon'
 import Form from 'components/Form'
 
 function DashboardImmersionPresentation({
+  queryResponse,
   headerContent,
-  isLoading,
   tileContent,
-  labels,
   site,
   currentLabel,
   setCurrentLabel,
@@ -36,7 +35,7 @@ function DashboardImmersionPresentation({
         <div className="grid grid-cols-6">
           <div className="col-span-4">
             <DashboardTable.Presentation
-              isLoading={isLoading}
+              queryResponse={queryResponse}
               title="Immersion Labels"
               tableHead={
                 <tr>
@@ -55,7 +54,7 @@ function DashboardImmersionPresentation({
                   </th>
                 </tr>
               }
-              tableBody={labels.map((label) => (
+              tableBody={queryResponse?.labels.map((label) => (
                 <tr
                   key={label?.transKey}
                   onClick={() => setCurrentLabel(label)}
@@ -100,11 +99,10 @@ function DashboardImmersionPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, func, object } = PropTypes
+const { array, func, object } = PropTypes
 DashboardImmersionPresentation.propTypes = {
-  labels: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
   site: object,
   tileContent: array,
   currentLabel: object,

--- a/src/components/DashboardJoinList/DashboardJoinListPresentation.js
+++ b/src/components/DashboardJoinList/DashboardJoinListPresentation.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import DashboardJoinCard from 'components/DashboardJoinCard'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function DashboardJoinListPresentation({ joinRequestsInfiniteQueryResponse }) {
   return (
@@ -24,24 +25,9 @@ function DashboardJoinListPresentation({ joinRequestsInfiniteQueryResponse }) {
                   ))}
                 </Fragment>
               ))}
-              <button
-                data-testid="load-btn"
-                type="button"
-                className={`${
-                  !joinRequestsInfiniteQueryResponse?.hasNextPage
-                    ? 'cursor-text'
-                    : ''
-                } text-blumine-800 font-semibold w-full text-center p-2 print:hidden`}
-                onClick={() =>
-                  joinRequestsInfiniteQueryResponse?.fetchNextPage()
-                }
-                disabled={
-                  !joinRequestsInfiniteQueryResponse?.hasNextPage ||
-                  joinRequestsInfiniteQueryResponse?.isFetchingNextPage
-                }
-              >
-                {joinRequestsInfiniteQueryResponse?.loadLabel}
-              </button>
+              <InfiniteLoadBtn
+                infiniteQueryResponse={joinRequestsInfiniteQueryResponse}
+              />
             </div>
           </div>
         ) : (
@@ -52,10 +38,6 @@ function DashboardJoinListPresentation({ joinRequestsInfiniteQueryResponse }) {
           </div>
         )}
       </div>
-      <div
-        ref={joinRequestsInfiniteQueryResponse?.loadRef}
-        className="w-full h-10"
-      />
     </div>
   )
 }

--- a/src/components/DashboardMediaAudio/DashboardMediaAudioContainer.js
+++ b/src/components/DashboardMediaAudio/DashboardMediaAudioContainer.js
@@ -8,19 +8,7 @@ import SelectorSearchbox from 'components/SelectorSearchbox'
 import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 
 function DashboardMediaAudioContainer() {
-  const {
-    data,
-    currentFile,
-    setCurrentFile,
-    displayedSearchTerm,
-    handleSearchSubmitWithUrlSync,
-    handleSearchTermChange,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-    loadLabel,
-  } = useMediaSearch({ type: TYPE_AUDIO })
+  const infiniteQueryResponse = useMediaSearch({ type: TYPE_AUDIO })
 
   return (
     <div
@@ -30,24 +18,20 @@ function DashboardMediaAudioContainer() {
       <div className="h-full w-full flex flex-col">
         <div className="w-full">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleSearchTermChange}
-            onSearchSubmit={handleSearchSubmitWithUrlSync}
+            onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+            onSearchSubmit={
+              infiniteQueryResponse?.handleSearchSubmitWithUrlSync
+            }
             searchPlaceholder="Search all audio"
-            searchValue={displayedSearchTerm}
+            searchValue={infiniteQueryResponse?.displayedSearchTerm}
           />
         </div>
         <div>
           <SelectorResultsWrapper.Presentation
-            hasResults={hasResults}
-            isLoading={isPending}
-            loadRef={loadRef}
+            infiniteQueryResponse={infiniteQueryResponse}
             resultsSection={
               <DashboardMediaAudioPresentation
-                data={data}
-                infiniteScroll={infiniteScroll}
-                currentFile={currentFile}
-                setCurrentFile={setCurrentFile}
-                loadLabel={loadLabel}
+                infiniteQueryResponse={infiniteQueryResponse}
               />
             }
           />

--- a/src/components/DashboardMediaAudio/DashboardMediaAudioContainer.js
+++ b/src/components/DashboardMediaAudio/DashboardMediaAudioContainer.js
@@ -10,20 +10,17 @@ import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 function DashboardMediaAudioContainer() {
   const {
     data,
-    searchValue,
     currentFile,
     setCurrentFile,
+    displayedSearchTerm,
     handleSearchSubmitWithUrlSync,
-    handleTextFieldChange,
+    handleSearchTermChange,
+    hasResults,
     infiniteScroll,
     isPending,
     loadRef,
     loadLabel,
   } = useMediaSearch({ type: TYPE_AUDIO })
-
-  const hasResults = !!(
-    data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0
-  )
 
   return (
     <div
@@ -33,10 +30,10 @@ function DashboardMediaAudioContainer() {
       <div className="h-full w-full flex flex-col">
         <div className="w-full">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleTextFieldChange}
+            onSearchChange={handleSearchTermChange}
             onSearchSubmit={handleSearchSubmitWithUrlSync}
             searchPlaceholder="Search all audio"
-            searchValue={searchValue}
+            searchValue={displayedSearchTerm}
           />
         </div>
         <div>

--- a/src/components/DashboardMediaAudio/DashboardMediaAudioPresentation.js
+++ b/src/components/DashboardMediaAudio/DashboardMediaAudioPresentation.js
@@ -5,16 +5,9 @@ import PropTypes from 'prop-types'
 import AudioNative from 'components/AudioNative'
 import MediaDetails from 'components/MediaDetails'
 import { TYPE_AUDIO } from 'common/constants'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
-function DashboardMediaAudioPresentation({
-  data,
-  infiniteScroll,
-  currentFile,
-  setCurrentFile,
-  loadLabel,
-}) {
-  const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
-
+function DashboardMediaAudioPresentation({ infiniteQueryResponse }) {
   const headerClass =
     'px-6 py-3 text-center text-xs font-medium text-charcoal-900 uppercase tracking-wider'
 
@@ -48,18 +41,21 @@ function DashboardMediaAudioPresentation({
                   </tr>
                 </thead>
                 <tbody className="bg-white divide-y divide-charcoal-100">
-                  {data?.pages?.[0]?.results?.length &&
-                    data?.pages?.map((page) => (
+                  {infiniteQueryResponse?.data?.pages?.[0]?.results?.length &&
+                    infiniteQueryResponse?.data?.pages?.map((page) => (
                       <React.Fragment key={page?.pageNumber}>
                         {page.results.map((audioFile) => (
                           <tr
                             key={audioFile?.id}
                             className={`${
-                              audioFile?.id === currentFile?.id
+                              audioFile?.id ===
+                              infiniteQueryResponse?.currentFile?.id
                                 ? 'ring-2 ring-offset-2 ring-blumine-800'
                                 : ''
                             } rounded-lg relative`}
-                            onClick={() => setCurrentFile(audioFile)}
+                            onClick={() =>
+                              infiniteQueryResponse?.setCurrentFile(audioFile)
+                            }
                           >
                             <td
                               className="px-2 py-2 overflow-visible w-80 text-sm text-charcoal-900"
@@ -82,36 +78,25 @@ function DashboardMediaAudioPresentation({
                     ))}
                 </tbody>
               </table>
-              <div className="pt-10 text-center text-charcoal-900 font-medium print:hidden">
-                <button
-                  data-testid="load-btn"
-                  type="button"
-                  className={!hasNextPage ? 'cursor-text' : ''}
-                  onClick={() => fetchNextPage()}
-                  disabled={!hasNextPage || isFetchingNextPage}
-                >
-                  {loadLabel}
-                </button>
-              </div>
+              <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
             </div>
           </div>
         </section>
       </main>
       <aside className="col-span-1 bg-white p-8 border-1 border-charcoal-100">
-        <MediaDetails.Audio file={currentFile} docType={TYPE_AUDIO} />
+        <MediaDetails.Audio
+          file={infiniteQueryResponse?.currentFile}
+          docType={TYPE_AUDIO}
+        />
       </aside>
     </div>
   )
 }
 
 // PROPTYPES
-const { func, object, string } = PropTypes
+const { object } = PropTypes
 DashboardMediaAudioPresentation.propTypes = {
-  data: object,
-  infiniteScroll: object,
-  currentFile: object,
-  setCurrentFile: func,
-  loadLabel: string,
+  infiniteQueryResponse: object,
 }
 
 export default DashboardMediaAudioPresentation

--- a/src/components/DashboardMediaVisual/DashboardMediaVisualContainer.js
+++ b/src/components/DashboardMediaVisual/DashboardMediaVisualContainer.js
@@ -11,21 +11,18 @@ import { TYPE_IMAGE, TYPE_VIDEO } from 'common/constants'
 function DashboardMediaVisualContainer({ type }) {
   const {
     data,
-    searchValue,
     currentFile,
     setCurrentFile,
+    displayedSearchTerm,
     handleSearchSubmitWithUrlSync,
-    handleTextFieldChange,
+    handleSearchTermChange,
+    hasResults,
     infiniteScroll,
     isPending,
     loadRef,
     loadLabel,
     typePlural,
   } = useMediaSearch({ type })
-
-  const hasResults = !!(
-    data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0
-  )
 
   return (
     <div
@@ -35,10 +32,10 @@ function DashboardMediaVisualContainer({ type }) {
       <div className="h-full w-full flex flex-col">
         <div className="w-full">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleTextFieldChange}
+            onSearchChange={handleSearchTermChange}
             onSearchSubmit={handleSearchSubmitWithUrlSync}
             searchPlaceholder={`Search all ${typePlural}`}
-            searchValue={searchValue}
+            searchValue={displayedSearchTerm}
           />
         </div>
         <div>

--- a/src/components/DashboardMediaVisual/DashboardMediaVisualContainer.js
+++ b/src/components/DashboardMediaVisual/DashboardMediaVisualContainer.js
@@ -9,20 +9,7 @@ import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 import { TYPE_IMAGE, TYPE_VIDEO } from 'common/constants'
 
 function DashboardMediaVisualContainer({ type }) {
-  const {
-    data,
-    currentFile,
-    setCurrentFile,
-    displayedSearchTerm,
-    handleSearchSubmitWithUrlSync,
-    handleSearchTermChange,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-    loadLabel,
-    typePlural,
-  } = useMediaSearch({ type })
+  const infiniteQueryResponse = useMediaSearch({ type })
 
   return (
     <div
@@ -32,26 +19,21 @@ function DashboardMediaVisualContainer({ type }) {
       <div className="h-full w-full flex flex-col">
         <div className="w-full">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleSearchTermChange}
-            onSearchSubmit={handleSearchSubmitWithUrlSync}
-            searchPlaceholder={`Search all ${typePlural}`}
-            searchValue={displayedSearchTerm}
+            onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+            onSearchSubmit={
+              infiniteQueryResponse?.handleSearchSubmitWithUrlSync
+            }
+            searchPlaceholder={`Search all ${infiniteQueryResponse?.typePlural}`}
+            searchValue={infiniteQueryResponse?.displayedSearchTerm}
           />
         </div>
         <div>
           <SelectorResultsWrapper.Presentation
-            hasResults={hasResults}
-            isLoading={isPending}
-            loadRef={loadRef}
+            infiniteQueryResponse={infiniteQueryResponse}
             resultsSection={
               <DashboardMediaVisualPresentation
-                data={data}
-                infiniteScroll={infiniteScroll}
-                currentFile={currentFile}
-                setCurrentFile={setCurrentFile}
-                loadLabel={loadLabel}
+                infiniteQueryResponse={infiniteQueryResponse}
                 type={type}
-                typePlural={typePlural}
               />
             }
           />

--- a/src/components/DashboardMediaVisual/DashboardMediaVisualPresentation.js
+++ b/src/components/DashboardMediaVisual/DashboardMediaVisualPresentation.js
@@ -5,17 +5,9 @@ import PropTypes from 'prop-types'
 import MediaDetails from 'components/MediaDetails'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import { SMALL, IMAGE } from 'common/constants'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
-function DashboardMediaVisualPresentation({
-  data,
-  infiniteScroll,
-  currentFile,
-  setCurrentFile,
-  loadLabel,
-  type,
-  typePlural,
-}) {
-  const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
+function DashboardMediaVisualPresentation({ infiniteQueryResponse, type }) {
   return (
     <div
       id="DashboardMediaVisualPresentation"
@@ -27,14 +19,15 @@ function DashboardMediaVisualPresentation({
             id="results-header"
             className="capitalize flex text-2xl font-bold text-charcoal-900 mb-4"
           >
-            {typePlural}
+            {infiniteQueryResponse?.typePlural}
           </h1>
           <div className="overflow-y-auto h-full">
             <div>
               <ul className="p-2 grid grid-cols-4 gap-y-8 gap-x-6 xl:gap-x-8">
-                {data?.pages !== undefined &&
-                  data?.pages?.[0]?.results?.length > 0 &&
-                  data?.pages?.map((page) => (
+                {infiniteQueryResponse?.data?.pages !== undefined &&
+                  infiniteQueryResponse?.data?.pages?.[0]?.results?.length >
+                    0 &&
+                  infiniteQueryResponse?.data?.pages?.map((page) => (
                     <React.Fragment key={page?.pageNumber}>
                       {page.results.map((mediaObject) => {
                         const src = getMediaPath({
@@ -46,7 +39,8 @@ function DashboardMediaVisualPresentation({
                           <li key={mediaObject?.id} className="relative">
                             <div
                               className={`${
-                                mediaObject?.id === currentFile?.id
+                                mediaObject?.id ===
+                                infiniteQueryResponse?.currentFile?.id
                                   ? 'ring-4 ring-offset-2 ring-scarlet-800'
                                   : 'focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-offset-charcoal-50 focus-within:ring-scarlet-800'
                               } group block w-full aspect-w-10 aspect-h-7 rounded-lg bg-charcoal-50 overflow-hidden`}
@@ -55,7 +49,8 @@ function DashboardMediaVisualPresentation({
                                 src={src}
                                 alt={mediaObject?.title}
                                 className={`${
-                                  mediaObject?.id === currentFile?.id
+                                  mediaObject?.id ===
+                                  infiniteQueryResponse?.currentFile?.id
                                     ? ''
                                     : 'group-hover:opacity-75'
                                 } object-cover pointer-events-none`}
@@ -64,7 +59,11 @@ function DashboardMediaVisualPresentation({
                                 data-testid=""
                                 type="button"
                                 className="absolute inset-0 focus:outline-none"
-                                onClick={() => setCurrentFile(mediaObject)}
+                                onClick={() =>
+                                  infiniteQueryResponse?.setCurrentFile(
+                                    mediaObject,
+                                  )
+                                }
                               >
                                 <span className="sr-only">
                                   View details for {mediaObject?.title}
@@ -83,37 +82,25 @@ function DashboardMediaVisualPresentation({
                     </React.Fragment>
                   ))}
               </ul>
-              <div className="pt-10 text-center text-charcoal-900 font-medium">
-                <button
-                  data-testid="load-btn"
-                  type="button"
-                  className={!hasNextPage ? 'cursor-text' : ''}
-                  onClick={() => fetchNextPage()}
-                  disabled={!hasNextPage || isFetchingNextPage}
-                >
-                  {loadLabel}
-                </button>
-              </div>
+              <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
             </div>
           </div>
         </section>
       </main>
       <aside className="col-span-1 bg-white p-8 border-1 border-charcoal-100">
-        <MediaDetails.Visual file={currentFile} docType={type} />
+        <MediaDetails.Visual
+          file={infiniteQueryResponse?.currentFile}
+          docType={type}
+        />
       </aside>
     </div>
   )
 }
 // PROPTYPES
-const { func, object, string } = PropTypes
+const { object, string } = PropTypes
 DashboardMediaVisualPresentation.propTypes = {
-  data: object,
-  infiniteScroll: object,
-  currentFile: object,
-  setCurrentFile: func,
-  loadLabel: string,
+  infiniteQueryResponse: object,
   type: string,
-  typePlural: string,
 }
 
 export default DashboardMediaVisualPresentation

--- a/src/components/DashboardPages/DashboardPagesContainer.js
+++ b/src/components/DashboardPages/DashboardPagesContainer.js
@@ -5,22 +5,14 @@ import DashboardPagesData from 'components/DashboardPages/DashboardPagesData'
 import DashboardPagesPresentation from 'components/DashboardPages/DashboardPagesPresentation'
 
 function DashboardPagesContainer() {
-  const {
-    customPages,
-    headerContent,
-    pagesQueryResponse,
-    site,
-    sitename,
-    tileContent,
-  } = DashboardPagesData()
+  const { queryResponse, headerContent, site, tileContent } =
+    DashboardPagesData()
   return (
     <DashboardPagesPresentation
+      queryResponse={queryResponse}
       headerContent={headerContent}
       tileContent={tileContent}
-      customPages={customPages}
-      isLoading={pagesQueryResponse?.isPending}
       site={site}
-      sitename={sitename}
     />
   )
 }

--- a/src/components/DashboardPages/DashboardPagesData.js
+++ b/src/components/DashboardPages/DashboardPagesData.js
@@ -10,7 +10,7 @@ function DashboardPagesData() {
   const { sitename } = useParams()
 
   // Data fetch
-  const pagesQueryResponse = usePages()
+  const queryResponse = usePages()
 
   const tileContent = [
     {
@@ -38,15 +38,10 @@ function DashboardPagesData() {
   }
 
   return {
+    queryResponse,
     headerContent,
-    pagesQueryResponse,
     site,
-    sitename,
     tileContent,
-    customPages:
-      pagesQueryResponse?.data?.results?.length > 0
-        ? pagesQueryResponse?.data?.results
-        : [],
   }
 }
 

--- a/src/components/DashboardPages/DashboardPagesPresentation.js
+++ b/src/components/DashboardPages/DashboardPagesPresentation.js
@@ -8,24 +8,22 @@ import DashboardTable from 'components/DashboardTable'
 import getIcon from 'common/utils/getIcon'
 
 function DashboardPagesPresentation({
+  queryResponse,
   headerContent,
-  isLoading,
   tileContent,
-  customPages,
   site,
-  sitename,
 }) {
   const tableHeaderClass =
     'px-6 py-3 text-left text-xs font-medium text-charcoal-900 uppercase tracking-wider'
   return (
-    <div id="DashboardPagesPresentation" className="space-y-5">
+    <div data-testid="DashboardPagesPresentation" className="space-y-5">
       <DashboardLanding.Presentation
         tileContent={tileContent}
         headerContent={headerContent}
         site={site}
       >
         <DashboardTable.Presentation
-          isLoading={isLoading}
+          queryResponse={queryResponse}
           title="Custom Pages"
           tableHead={
             <tr>
@@ -47,7 +45,7 @@ function DashboardPagesPresentation({
               </th>
             </tr>
           }
-          tableBody={customPages.map((page) => (
+          tableBody={queryResponse?.data?.results?.map((page) => (
             <tr key={page.id}>
               <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
                 {page.title}
@@ -60,7 +58,7 @@ function DashboardPagesPresentation({
               </td>
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
-                  to={`/${sitename}/dashboard/edit/page?slug=${page?.url}`}
+                  to={`/${site?.sitename}/dashboard/edit/page?slug=${page?.url}`}
                   className="text-scarlet-800 hover:text-scarlet-900 flex items-center"
                 >
                   {getIcon('Pencil', 'fill-current w-6 h-6 mr-2')}
@@ -84,11 +82,10 @@ function DashboardPagesPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, object, string } = PropTypes
+const { array, object, string } = PropTypes
 DashboardPagesPresentation.propTypes = {
-  customPages: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
   site: object,
   sitename: string,
   tileContent: array,

--- a/src/components/DashboardSpeakers/DashboardSpeakersContainer.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersContainer.js
@@ -5,22 +5,14 @@ import DashboardSpeakersData from 'components/DashboardSpeakers/DashboardSpeaker
 import DashboardSpeakersPresentation from 'components/DashboardSpeakers/DashboardSpeakersPresentation'
 
 function DashboardSpeakersContainer() {
-  const {
-    speakers,
-    headerContent,
-    peopleQueryResponse,
-    site,
-    sitename,
-    tileContent,
-  } = DashboardSpeakersData()
+  const { queryResponse, headerContent, site, tileContent } =
+    DashboardSpeakersData()
   return (
     <DashboardSpeakersPresentation
+      queryResponse={queryResponse}
       headerContent={headerContent}
       tileContent={tileContent}
-      speakers={speakers}
-      isLoading={peopleQueryResponse?.isPending}
       site={site}
-      sitename={sitename}
     />
   )
 }

--- a/src/components/DashboardSpeakers/DashboardSpeakersData.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersData.js
@@ -8,7 +8,7 @@ function DashboardSpeakersData() {
   const { site } = useSiteStore()
   const { sitename } = useParams()
 
-  const peopleQueryResponse = usePeople()
+  const queryResponse = usePeople()
 
   const tileContent = [
     {
@@ -27,12 +27,10 @@ function DashboardSpeakersData() {
   }
 
   return {
+    queryResponse,
     headerContent,
     tileContent,
-    peopleQueryResponse,
     site,
-    sitename,
-    speakers: peopleQueryResponse?.data?.results || [],
   }
 }
 

--- a/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
@@ -8,12 +8,10 @@ import DashboardTable from 'components/DashboardTable'
 import getIcon from 'common/utils/getIcon'
 
 function DashboardSpeakersPresentation({
+  queryResponse,
   headerContent,
-  isLoading,
   tileContent,
-  speakers,
   site,
-  sitename,
 }) {
   const tableHeaderClass =
     'px-6 py-3 text-left text-xs font-medium text-charcoal-900 uppercase tracking-wider'
@@ -25,7 +23,7 @@ function DashboardSpeakersPresentation({
         site={site}
       >
         <DashboardTable.Presentation
-          isLoading={isLoading}
+          queryResponse={queryResponse}
           title="Speakers"
           tableHead={
             <tr>
@@ -41,7 +39,7 @@ function DashboardSpeakersPresentation({
               </th>
             </tr>
           }
-          tableBody={speakers.map((speaker) => (
+          tableBody={queryResponse?.data?.results?.map((speaker) => (
             <tr key={speaker.id}>
               <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
                 {speaker.name}
@@ -52,7 +50,7 @@ function DashboardSpeakersPresentation({
               <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <Link
                   data-testid={`edit-speaker-${speaker.name}`}
-                  to={`/${sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
+                  to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
                   className="text-scarlet-800 hover:text-scarlet-900 flex items-center"
                 >
                   {getIcon('Pencil', 'fill-current w-6 h-6 mr-2')}
@@ -66,13 +64,11 @@ function DashboardSpeakersPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, object, string } = PropTypes
+const { array, object } = PropTypes
 DashboardSpeakersPresentation.propTypes = {
-  speakers: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
   site: object,
-  sitename: string,
   tileContent: array,
 }
 

--- a/src/components/DashboardTable/DashboardTablePresentation.js
+++ b/src/components/DashboardTable/DashboardTablePresentation.js
@@ -2,16 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
-import Loading from 'components/Loading'
+import LoadOrError from 'components/LoadOrError'
 
 function DashboardTablePresentation({
   title,
-  isLoading,
+  queryResponse,
   tableHead,
   tableBody,
 }) {
   return (
-    <Loading.Container isLoading={isLoading}>
+    <LoadOrError queryResponse={queryResponse}>
       <section
         data-testid="DashboardTablePresentation"
         className="mx-auto h-full px-8"
@@ -43,13 +43,13 @@ function DashboardTablePresentation({
           </div>
         </div>
       </section>
-    </Loading.Container>
+    </LoadOrError>
   )
 }
 // PROPTYPES
-const { bool, node, string } = PropTypes
+const { object, node, string } = PropTypes
 DashboardTablePresentation.propTypes = {
-  isLoading: bool,
+  queryResponse: object,
   tableHead: node,
   tableBody: node,
   title: string,

--- a/src/components/DashboardWidgets/DashboardWidgetsContainer.js
+++ b/src/components/DashboardWidgets/DashboardWidgetsContainer.js
@@ -5,14 +5,13 @@ import DashboardWidgetsData from 'components/DashboardWidgets/DashboardWidgetsDa
 import DashboardWidgetsPresentation from 'components/DashboardWidgets/DashboardWidgetsPresentation'
 
 function DashboardWidgetsContainer() {
-  const { widgets, headerContent, widgetsQueryResponse, site, tileContent } =
+  const { queryResponse, headerContent, site, tileContent } =
     DashboardWidgetsData()
   return (
     <DashboardWidgetsPresentation
+      queryResponse={queryResponse}
       headerContent={headerContent}
       tileContent={tileContent}
-      widgets={widgets}
-      isLoading={widgetsQueryResponse?.isPending}
       site={site}
     />
   )

--- a/src/components/DashboardWidgets/DashboardWidgetsData.js
+++ b/src/components/DashboardWidgets/DashboardWidgetsData.js
@@ -9,7 +9,7 @@ function DashboardWidgetsData() {
   const { sitename } = useParams()
 
   // Data fetch
-  const widgetsQueryResponse = useWidgets()
+  const queryResponse = useWidgets()
 
   const tileContent = [
     {
@@ -29,14 +29,10 @@ function DashboardWidgetsData() {
   }
 
   return {
+    queryResponse,
     headerContent,
-    widgetsQueryResponse,
     site,
     tileContent,
-    widgets:
-      widgetsQueryResponse?.widgets?.length > 0
-        ? widgetsQueryResponse?.widgets
-        : [],
   }
 }
 

--- a/src/components/DashboardWidgets/DashboardWidgetsPresentation.js
+++ b/src/components/DashboardWidgets/DashboardWidgetsPresentation.js
@@ -10,10 +10,9 @@ import Modal from 'components/Modal'
 import Widget from 'components/Widget'
 
 function DashboardWidgetsPresentation({
+  queryResponse,
   headerContent,
-  isLoading,
   tileContent,
-  widgets,
   site,
 }) {
   const [previewModalOpen, setPreviewModalOpen] = useState(false)
@@ -29,7 +28,7 @@ function DashboardWidgetsPresentation({
         site={site}
       >
         <DashboardTable.Presentation
-          isLoading={isLoading}
+          queryResponse={queryResponse}
           title="Widgets"
           tableHead={
             <tr>
@@ -48,7 +47,7 @@ function DashboardWidgetsPresentation({
               </th>
             </tr>
           }
-          tableBody={widgets.map((widget) => (
+          tableBody={queryResponse?.widgets?.map((widget) => (
             <tr key={widget?.id}>
               <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-charcoal-900">
                 {widget?.nickname}
@@ -96,11 +95,10 @@ function DashboardWidgetsPresentation({
   )
 }
 // PROPTYPES
-const { array, bool, object } = PropTypes
+const { array, object } = PropTypes
 DashboardWidgetsPresentation.propTypes = {
-  widgets: array,
+  queryResponse: object,
   headerContent: object,
-  isLoading: bool,
   site: object,
   tileContent: array,
 }

--- a/src/components/Dictionary/DictionaryPresentation.js
+++ b/src/components/Dictionary/DictionaryPresentation.js
@@ -1,17 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-router-dom'
 
 import DictionaryList from 'components/DictionaryList'
 import DictionaryGrid from 'components/DictionaryGrid'
 import SearchDictionaryForm from 'components/SearchDictionaryForm'
-import getIcon from 'common/utils/getIcon'
-import {
-  TYPES,
-  TYPE_DICTIONARY,
-  TYPE_PHRASE,
-  TYPE_WORD,
-} from 'common/constants'
+import DictionaryLinks from 'components/DictionaryLinks'
+import { TYPE_DICTIONARY } from 'common/constants'
 
 function DictionaryPresentation({
   searchType,
@@ -20,12 +14,6 @@ function DictionaryPresentation({
   labels,
   sitename,
 }) {
-  const linkStyle = {
-    li: 'block transition duration-500 ease-in-out ml-5 xl:ml-8',
-    link: 'flex items-center transition duration-500 ease-in-out p-2 grow rounded-lg capitalize cursor-pointer text-lg xl:text-xl text-charcoal-900',
-    icon: 'inline-flex fill-current w-6 xl:w-8 mr-2 xl:mr-5',
-  }
-
   const count =
     infiniteQueryResponse?.data?.pages?.[0]?.count < 10000
       ? infiniteQueryResponse?.data?.pages?.[0]?.count
@@ -68,46 +56,7 @@ function DictionaryPresentation({
                 Results: {count}
               </div>
             </div>
-
-            <h2 className="block text-xl xl:text-2xl font-medium text-charcoal-900 ml-4 xl:ml-7">
-              BROWSE BY:
-            </h2>
-            <ul className="inline-block list-none">
-              <li id="CategoryLink" className={linkStyle.li}>
-                <Link
-                  className={linkStyle.link}
-                  to={`/${sitename}/categories?${TYPES}=${searchType}`}
-                >
-                  {getIcon('Categories', linkStyle.icon)}
-                  <p>Categories</p>
-                </Link>
-              </li>
-              <li id="AlphabetLink" className={linkStyle.li}>
-                <Link
-                  className={linkStyle.link}
-                  to={`/${sitename}/alphabet?${TYPES}=${searchType}`}
-                >
-                  {getIcon('Alphabet', linkStyle.icon)}
-                  <p>Alphabet</p>
-                </Link>
-              </li>
-              {searchType !== TYPE_WORD && (
-                <li id="DocLink" className={linkStyle.li}>
-                  <Link className={linkStyle.link} to={`/${sitename}/words`}>
-                    {getIcon('Word', linkStyle.icon)}
-                    <p>Words</p>
-                  </Link>
-                </li>
-              )}
-              {searchType !== TYPE_PHRASE && (
-                <li id="DocLink" className={linkStyle.li}>
-                  <Link className={linkStyle.link} to={`/${sitename}/phrases`}>
-                    {getIcon('Phrase', linkStyle.icon)}
-                    <p>Phrases</p>
-                  </Link>
-                </li>
-              )}
-            </ul>
+            <DictionaryLinks />
           </div>
           <div className="col-span-12 lg:col-span-10">
             <div className="hidden md:block p-2 print:block">

--- a/src/components/Dictionary/DictionaryPresentation.js
+++ b/src/components/Dictionary/DictionaryPresentation.js
@@ -109,7 +109,7 @@ function DictionaryPresentation({
               )}
             </ul>
           </div>
-          <div className="min-h-220 col-span-12 lg:col-span-10">
+          <div className="col-span-12 lg:col-span-10">
             <div className="hidden md:block p-2 print:block">
               <DictionaryList.Presentation
                 infiniteQueryResponse={infiniteQueryResponse}
@@ -128,7 +128,6 @@ function DictionaryPresentation({
           </div>
         </div>
       )}
-      <div ref={infiniteQueryResponse?.loadRef} className="w-full h-10" />
     </>
   )
 }

--- a/src/components/DictionaryGrid/DictionaryGridPresentation.js
+++ b/src/components/DictionaryGrid/DictionaryGridPresentation.js
@@ -6,6 +6,7 @@ import LoadOrError from 'components/LoadOrError'
 import getIcon from 'common/utils/getIcon'
 import DictionaryGridTile from 'components/DictionaryGridTile'
 import LazyLoader from 'components/LazyLoader'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn/InfiniteLoadBtn'
 
 function DictionaryGridPresentation({
   infiniteQueryResponse,
@@ -26,8 +27,7 @@ function DictionaryGridPresentation({
 
   return (
     <LoadOrError queryResponse={infiniteQueryResponse}>
-      {infiniteQueryResponse?.data?.pages !== undefined &&
-      infiniteQueryResponse?.data?.pages?.[0]?.results?.length > 0 ? (
+      {infiniteQueryResponse?.hasResults ? (
         <div id="DictionaryGridPresentation" className="mx-auto flex flex-col">
           <div className="p-4 align-middle inline-block min-w-full relative">
             {/* Hiding print button until custom print view has been created */}
@@ -61,22 +61,7 @@ function DictionaryGridPresentation({
               </div>
             ))}
           </div>
-          <div className="p-3 text-center text-charcoal-900 font-medium print:hidden">
-            <button
-              data-testid="load-btn"
-              type="button"
-              className={
-                !infiniteQueryResponse?.hasNextPage ? 'cursor-text' : ''
-              }
-              onClick={() => infiniteQueryResponse?.fetchNextPage()}
-              disabled={
-                !infiniteQueryResponse?.hasNextPage ||
-                infiniteQueryResponse?.isFetchingNextPage
-              }
-            >
-              {infiniteQueryResponse?.loadLabel}
-            </button>
-          </div>
+          <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
         </div>
       ) : (
         <div className="w-full flex">

--- a/src/components/DictionaryLinks/DictionaryLink.js
+++ b/src/components/DictionaryLinks/DictionaryLink.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Link } from 'react-router-dom'
+
+// FPCC
+import getIcon from 'common/utils/getIcon'
+
+function DictionaryLink({ linkProperties }) {
+  return (
+    <li
+      id={linkProperties?.id}
+      className="transition duration-500 ease-in-out ml-5 xl:ml-8"
+    >
+      <Link
+        className="flex items-center transition duration-500 ease-in-out p-2 grow rounded-lg capitalize cursor-pointer text-lg xl:text-xl text-charcoal-900"
+        to={linkProperties?.linkTo}
+      >
+        {getIcon(
+          linkProperties?.iconId,
+          'inline-flex fill-current w-6 xl:w-8 mr-2 xl:mr-5',
+        )}
+        <span>{linkProperties?.label}</span>
+      </Link>
+    </li>
+  )
+}
+// PROPTYPES
+const { object } = PropTypes
+DictionaryLink.propTypes = {
+  linkProperties: object,
+}
+
+export default DictionaryLink

--- a/src/components/DictionaryLinks/DictionaryLinks.js
+++ b/src/components/DictionaryLinks/DictionaryLinks.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import { useParams, useLocation } from 'react-router-dom'
+
+// FPCC
+import DictionaryLink from 'components/DictionaryLinks/DictionaryLink'
+
+function DictionaryLinks() {
+  const { sitename } = useParams()
+  const { pathname } = useLocation()
+  return (
+    <div role="navigation">
+      <h2 className="text-xl xl:text-2xl font-medium ml-4 xl:ml-7 text-charcoal-900">
+        BROWSE BY:
+      </h2>
+      <ul className="inline-block list-none">
+        {!pathname?.includes('categories') && (
+          <DictionaryLink
+            key="CategoriesLink"
+            linkProperties={{
+              id: 'CategoryLink',
+              iconId: 'Categories',
+              linkTo: `/${sitename}/categories`,
+              label: 'Categories',
+            }}
+          />
+        )}
+        {!pathname?.includes('alphabet') && (
+          <DictionaryLink
+            key="AlphabetLink"
+            linkProperties={{
+              id: 'AlphabetLink',
+              iconId: 'Alphabet',
+              linkTo: `/${sitename}/alphabet`,
+              label: 'Alphabet',
+            }}
+          />
+        )}
+        {!pathname?.includes('/words') && (
+          <DictionaryLink
+            key="WordsLink"
+            linkProperties={{
+              id: 'WordsLink',
+              iconId: 'Word',
+              linkTo: `/${sitename}/words`,
+              label: 'Words',
+            }}
+          />
+        )}
+        {!pathname?.includes('/phrases') && (
+          <DictionaryLink
+            key="PhrasesLink"
+            linkProperties={{
+              id: 'PhrasesLink',
+              iconId: 'Phrase',
+              linkTo: `/${sitename}/phrases`,
+              label: 'Phrases',
+            }}
+          />
+        )}
+      </ul>
+    </div>
+  )
+}
+
+export default DictionaryLinks

--- a/src/components/DictionaryLinks/DictionaryLinks.js
+++ b/src/components/DictionaryLinks/DictionaryLinks.js
@@ -8,7 +8,7 @@ function DictionaryLinks() {
   const { sitename } = useParams()
   const { pathname } = useLocation()
   return (
-    <div data-testid="DictionaryLinks" role="navigation">
+    <nav data-testid="DictionaryLinks">
       <h2 className="text-xl xl:text-2xl font-medium ml-4 xl:ml-7 text-charcoal-900">
         BROWSE BY:
       </h2>
@@ -58,7 +58,7 @@ function DictionaryLinks() {
           />
         )}
       </ul>
-    </div>
+    </nav>
   )
 }
 

--- a/src/components/DictionaryLinks/DictionaryLinks.js
+++ b/src/components/DictionaryLinks/DictionaryLinks.js
@@ -8,7 +8,7 @@ function DictionaryLinks() {
   const { sitename } = useParams()
   const { pathname } = useLocation()
   return (
-    <div role="navigation">
+    <div data-testid="DictionaryLinks" role="navigation">
       <h2 className="text-xl xl:text-2xl font-medium ml-4 xl:ml-7 text-charcoal-900">
         BROWSE BY:
       </h2>

--- a/src/components/DictionaryLinks/index.js
+++ b/src/components/DictionaryLinks/index.js
@@ -1,0 +1,3 @@
+import DictionaryLinks from 'components/DictionaryLinks/DictionaryLinks'
+
+export default DictionaryLinks

--- a/src/components/DictionaryList/DictionaryListPresentation.js
+++ b/src/components/DictionaryList/DictionaryListPresentation.js
@@ -11,6 +11,7 @@ import Drawer from 'components/Drawer'
 import EntryDetail from 'components/EntryDetail'
 import AudioButton from 'components/AudioButton'
 import { useAudiobar } from 'context/AudiobarContext'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn/InfiniteLoadBtn'
 
 function DictionaryListPresentation({
   infiniteQueryResponse,
@@ -56,12 +57,14 @@ function DictionaryListPresentation({
 
   return (
     <LoadOrError queryResponse={infiniteQueryResponse}>
-      {infiniteQueryResponse?.data?.pages !== undefined &&
-      infiniteQueryResponse?.data?.pages?.[0]?.results?.length > 0 ? (
-        <div id="DictionaryListPresentation" className="flex flex-col">
-          <div className="py-2 align-middle inline-block min-w-full">
-            <div className="overflow-hidden sm:rounded-lg">
-              <table className="min-w-full divide-y border-b-2 mb-20 divide-charcoal-200">
+      <section
+        data-testid="DictionaryListPresentation"
+        className="bg-white min-h-screen w-full"
+      >
+        {infiniteQueryResponse?.hasResults ? (
+          <div className="flex flex-col w-full py-2">
+            <div className="border-b border-charcoal-200 rounded-lg overflow-hidden">
+              <table className="table-auto w-full divide-y divide-charcoal-200">
                 <thead className="bg-charcoal-50">
                   <tr>
                     <th scope="col" className="px-6 py-3">
@@ -192,31 +195,17 @@ function DictionaryListPresentation({
                 </tbody>
               </table>
             </div>
+            <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
           </div>
-          <div className="p-3 text-center text-charcoal-900 font-medium print:hidden">
-            <button
-              data-testid="load-btn"
-              type="button"
-              className={
-                !infiniteQueryResponse?.hasNextPage ? 'cursor-text' : ''
-              }
-              onClick={() => infiniteQueryResponse?.fetchNextPage()}
-              disabled={
-                !infiniteQueryResponse?.hasNextPage ||
-                infiniteQueryResponse?.isFetchingNextPage
-              }
-            >
-              {infiniteQueryResponse?.loadLabel}
-            </button>
+        ) : (
+          <div className="w-full flex">
+            <div className="mx-6 mt-4 text-center md:mx-auto md:mt-20">
+              {noResultsMessage}
+            </div>
           </div>
-        </div>
-      ) : (
-        <div className="w-full flex">
-          <div className="mx-6 mt-4 text-center md:mx-auto md:mt-20">
-            {noResultsMessage}
-          </div>
-        </div>
-      )}
+        )}
+      </section>
+
       <Drawer.Presentation
         isOpen={drawerOpen}
         closeHandler={() => setDrawerOpen(false)}

--- a/src/components/InfiniteLoadBtn/InfiniteLoadBtn.js
+++ b/src/components/InfiniteLoadBtn/InfiniteLoadBtn.js
@@ -2,24 +2,39 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
+import useIntersectionObserver from 'common/hooks/useIntersectionObserver'
 
 function InfiniteLoadBtn({ infiniteQueryResponse }) {
+  const { loadRef } = useIntersectionObserver({
+    hasNextPage: infiniteQueryResponse?.hasNextPage,
+    fetchNextPage: infiniteQueryResponse?.fetchNextPage,
+  })
+
+  const getLoadLabel = () => {
+    if (infiniteQueryResponse?.isFetchingNextPage) {
+      return 'Loading more...'
+    }
+    if (infiniteQueryResponse?.hasNextPage) {
+      return 'Load more'
+    }
+    return 'End of results.'
+  }
   return (
-    <div data-testid="InfiniteLoadBtn" className="text-center">
-      <div ref={infiniteQueryResponse?.loadRef} className="w-full h-5" />
+    <div data-testid="InfiniteLoadBtn" className="text-center w-full">
+      <div ref={loadRef} className="w-full h-10" />
       <button
         data-testid="load-btn"
         type="button"
         className={`${
           !infiniteQueryResponse?.hasNextPage ? 'cursor-text' : ''
-        } p-3  text-charcoal-900 font-medium print:hidden`}
+        } p-3 mx-auto text-charcoal-900 font-medium print:hidden`}
         onClick={() => infiniteQueryResponse?.fetchNextPage()}
         disabled={
           !infiniteQueryResponse?.hasNextPage ||
           infiniteQueryResponse?.isFetchingNextPage
         }
       >
-        {infiniteQueryResponse?.loadLabel}
+        {getLoadLabel()}
       </button>
     </div>
   )

--- a/src/components/InfiniteLoadBtn/InfiniteLoadBtn.js
+++ b/src/components/InfiniteLoadBtn/InfiniteLoadBtn.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// FPCC
+
+function InfiniteLoadBtn({ infiniteQueryResponse }) {
+  return (
+    <div data-testid="InfiniteLoadBtn" className="text-center">
+      <div ref={infiniteQueryResponse?.loadRef} className="w-full h-5" />
+      <button
+        data-testid="load-btn"
+        type="button"
+        className={`${
+          !infiniteQueryResponse?.hasNextPage ? 'cursor-text' : ''
+        } p-3  text-charcoal-900 font-medium print:hidden`}
+        onClick={() => infiniteQueryResponse?.fetchNextPage()}
+        disabled={
+          !infiniteQueryResponse?.hasNextPage ||
+          infiniteQueryResponse?.isFetchingNextPage
+        }
+      >
+        {infiniteQueryResponse?.loadLabel}
+      </button>
+    </div>
+  )
+}
+
+// PROPTYPES
+const { object } = PropTypes
+InfiniteLoadBtn.propTypes = {
+  infiniteQueryResponse: object,
+}
+
+export default InfiniteLoadBtn

--- a/src/components/InfiniteLoadBtn/index.js
+++ b/src/components/InfiniteLoadBtn/index.js
@@ -1,0 +1,3 @@
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn/InfiniteLoadBtn'
+
+export default InfiniteLoadBtn

--- a/src/components/Search/SearchPresentation.js
+++ b/src/components/Search/SearchPresentation.js
@@ -73,7 +73,7 @@ function SearchPresentation({
             {getFilterListItems()}
           </ul>
         </div>
-        <div className="hidden md:block min-h-220 col-span-11 lg:col-span-9">
+        <div className="hidden md:block col-span-11 lg:col-span-9">
           <DictionaryList.Presentation
             infiniteQueryResponse={infiniteQueryResponse}
             sitename={sitename}
@@ -82,7 +82,7 @@ function SearchPresentation({
             entryLabel={entryLabel}
           />
         </div>
-        <div className="block md:hidden min-h-220 col-span-11">
+        <div className="block md:hidden col-span-11">
           <DictionaryGrid.Presentation
             infiniteQueryResponse={infiniteQueryResponse}
             sitename={sitename}
@@ -90,7 +90,6 @@ function SearchPresentation({
           />
         </div>
       </div>
-      <div ref={infiniteQueryResponse?.loadRef} className="w-full h-10" />
     </div>
   )
 }

--- a/src/components/SelectorAudio/SelectorAudioContainer.js
+++ b/src/components/SelectorAudio/SelectorAudioContainer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import SelectorSearchbox from 'components/SelectorSearchbox'
 import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 import SelectorAudioPresentation from 'components/SelectorAudio/SelectorAudioPresentation'
-import useMediaSearch from 'common/dataHooks/useMediaSearch'
+import useMediaSearchModal from 'common/dataHooks/useMediaSearchModal'
 import { TYPE_AUDIO } from 'common/constants'
 
 function SelectorAudioContainer({
@@ -15,28 +15,25 @@ function SelectorAudioContainer({
 }) {
   const {
     data,
-    searchValue,
+    displayedSearchTerm,
     handleSearchSubmit,
-    handleTextFieldChange,
+    handleSearchTermChange,
+    hasResults,
     infiniteScroll,
     isPending,
     loadRef,
     loadLabel,
-  } = useMediaSearch({ type: TYPE_AUDIO })
-
-  const hasResults = !!(
-    data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0
-  )
+  } = useMediaSearchModal({ type: TYPE_AUDIO })
 
   return (
     <div data-testid="SelectorAudioContainer" className="h-full bg-charcoal-50">
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleTextFieldChange}
+            onSearchChange={handleSearchTermChange}
             onSearchSubmit={handleSearchSubmit}
             searchPlaceholder="Search all audio"
-            searchValue={searchValue}
+            searchValue={displayedSearchTerm}
           />
         </div>
         <div className="grow mt-2 h-72 overflow-y-scroll">

--- a/src/components/SelectorAudio/SelectorAudioContainer.js
+++ b/src/components/SelectorAudio/SelectorAudioContainer.js
@@ -13,39 +13,25 @@ function SelectorAudioContainer({
   selectedMedia,
   mediaSelectHandler,
 }) {
-  const {
-    data,
-    displayedSearchTerm,
-    handleSearchSubmit,
-    handleSearchTermChange,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-    loadLabel,
-  } = useMediaSearchModal({ type: TYPE_AUDIO })
+  const infiniteQueryResponse = useMediaSearchModal({ type: TYPE_AUDIO })
 
   return (
     <div data-testid="SelectorAudioContainer" className="h-full bg-charcoal-50">
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleSearchTermChange}
-            onSearchSubmit={handleSearchSubmit}
+            onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+            onSearchSubmit={infiniteQueryResponse?.handleSearchSubmit}
             searchPlaceholder="Search all audio"
-            searchValue={displayedSearchTerm}
+            searchValue={infiniteQueryResponse?.displayedSearchTerm}
           />
         </div>
         <div className="grow mt-2 h-72 overflow-y-scroll">
           <SelectorResultsWrapper.Presentation
-            hasResults={hasResults}
-            isLoading={isPending}
-            loadRef={loadRef}
+            infiniteQueryResponse={infiniteQueryResponse}
             resultsSection={
               <SelectorAudioPresentation
-                data={data}
-                infiniteScroll={infiniteScroll}
-                loadLabel={loadLabel}
+                infiniteQueryResponse={infiniteQueryResponse}
                 formMedia={formMedia}
                 selectedMedia={selectedMedia}
                 mediaSelectHandler={mediaSelectHandler}

--- a/src/components/SelectorAudio/SelectorAudioPresentation.js
+++ b/src/components/SelectorAudio/SelectorAudioPresentation.js
@@ -4,17 +4,14 @@ import PropTypes from 'prop-types'
 // FPCC
 import AudioNative from 'components/AudioNative'
 import getIcon from 'common/utils/getIcon'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function SelectorAudioPresentation({
-  data,
-  infiniteScroll,
-  loadLabel,
+  infiniteQueryResponse,
   formMedia,
   selectedMedia,
   mediaSelectHandler,
 }) {
-  const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
-
   const headerClass =
     'px-6 py-3 text-center text-xs font-medium text-charcoal-900 uppercase tracking-wider'
 
@@ -46,8 +43,8 @@ function SelectorAudioPresentation({
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-charcoal-100">
-            {data?.pages?.[0]?.results?.length &&
-              data?.pages?.map((page) => (
+            {infiniteQueryResponse?.hasResults &&
+              infiniteQueryResponse?.data?.pages?.map((page) => (
                 <React.Fragment key={page?.pageNumber}>
                   {page.results.map((audioFile) => {
                     if (formMedia?.some((elemId) => elemId === audioFile?.id)) {
@@ -92,28 +89,16 @@ function SelectorAudioPresentation({
               ))}
           </tbody>
         </table>
-        <div className="pt-10 text-center text-charcoal-900 font-medium print:hidden">
-          <button
-            data-testid="load-btn"
-            type="button"
-            className={!hasNextPage ? 'cursor-text' : ''}
-            onClick={() => fetchNextPage()}
-            disabled={!hasNextPage || isFetchingNextPage}
-          >
-            {loadLabel}
-          </button>
-        </div>
+        <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
       </div>
     </div>
   )
 }
 
 // PROPTYPES
-const { array, func, object, string } = PropTypes
+const { array, func, object } = PropTypes
 SelectorAudioPresentation.propTypes = {
-  data: object,
-  infiniteScroll: object,
-  loadLabel: string,
+  infiniteQueryResponse: object,
   formMedia: array,
   selectedMedia: array,
   mediaSelectHandler: func,

--- a/src/components/SelectorEntries/SelectorEntriesContainer.js
+++ b/src/components/SelectorEntries/SelectorEntriesContainer.js
@@ -17,16 +17,7 @@ function SelectorEntriesContainer({
   updateFormEntries,
   visibility,
 }) {
-  const {
-    displayedSearchTerm,
-    handleSearchTermChange,
-    handleSearchSubmit,
-    data,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-  } = useSearchModal({ types, visibility })
+  const infiniteQueryResponse = useSearchModal({ types, visibility })
 
   const { selectedItems, setSelectedItems, handleSelectAdditionalItems } =
     useArrayStateManager({ maxItems: 30 })
@@ -68,24 +59,21 @@ function SelectorEntriesContainer({
             <div className="h-full w-full flex flex-col">
               <div className="w-3/4 mx-auto">
                 <SelectorSearchbox.Presentation
-                  onSearchChange={handleSearchTermChange}
-                  onSearchSubmit={handleSearchSubmit}
+                  onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+                  onSearchSubmit={infiniteQueryResponse?.handleSearchSubmit}
                   searchPlaceholder="Search all words and phrases"
-                  searchValue={displayedSearchTerm}
+                  searchValue={infiniteQueryResponse?.displayedSearchTerm}
                 />
               </div>
               <div className="grow h-72 overflow-y-scroll">
                 <SelectorResultsWrapper.Presentation
-                  hasResults={hasResults}
-                  isLoading={isPending}
-                  loadRef={loadRef}
+                  infiniteQueryResponse={infiniteQueryResponse}
                   resultsSection={
                     <SelectorEntriesPresentationList
+                      infiniteQueryResponse={infiniteQueryResponse}
                       formEntries={formEntries}
-                      handleSelectAdditionalItems={handleSelectAdditionalItems}
-                      infiniteScroll={infiniteScroll}
-                      searchResults={data}
                       selectedItems={selectedItems}
+                      handleSelectAdditionalItems={handleSelectAdditionalItems}
                       types={types}
                     />
                   }

--- a/src/components/SelectorEntries/SelectorEntriesContainer.js
+++ b/src/components/SelectorEntries/SelectorEntriesContainer.js
@@ -21,10 +21,10 @@ function SelectorEntriesContainer({
     displayedSearchTerm,
     handleSearchTermChange,
     handleSearchSubmit,
-    searchResults,
+    data,
     hasResults,
     infiniteScroll,
-    isLoadingEntries,
+    isPending,
     loadRef,
   } = useSearchModal({ types, visibility })
 
@@ -77,14 +77,14 @@ function SelectorEntriesContainer({
               <div className="grow h-72 overflow-y-scroll">
                 <SelectorResultsWrapper.Presentation
                   hasResults={hasResults}
-                  isLoading={isLoadingEntries}
+                  isLoading={isPending}
                   loadRef={loadRef}
                   resultsSection={
                     <SelectorEntriesPresentationList
                       formEntries={formEntries}
                       handleSelectAdditionalItems={handleSelectAdditionalItems}
                       infiniteScroll={infiniteScroll}
-                      searchResults={searchResults}
+                      searchResults={data}
                       selectedItems={selectedItems}
                       types={types}
                     />

--- a/src/components/SelectorEntries/SelectorEntriesPresentationList.js
+++ b/src/components/SelectorEntries/SelectorEntriesPresentationList.js
@@ -5,18 +5,15 @@ import { useSearchParams } from 'react-router-dom'
 // FPCC
 import { getFriendlyDocType } from 'common/utils/stringHelpers'
 import getIcon from 'common/utils/getIcon'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function SelectorEntriesPresentationList({
+  infiniteQueryResponse,
   formEntries,
-  searchResults,
-  infiniteScroll,
   selectedItems,
   handleSelectAdditionalItems,
   types,
 }) {
-  const { isFetchingNextPage, fetchNextPage, hasNextPage, loadLabel } =
-    infiniteScroll
-
   const [searchParams] = useSearchParams()
   const entryId = searchParams.get('id') || null
 
@@ -28,112 +25,101 @@ function SelectorEntriesPresentationList({
   return (
     <div id="SelectorEntriesPresentationList" className="w-full my-4 px-2">
       <h2 className="sr-only">Search results</h2>
-      {searchResults?.pages !== undefined &&
-        searchResults?.pages?.[0]?.results?.length > 0 && (
-          <>
-            <table className="min-w-full divide-y divide-charcoal-100">
-              <thead className="bg-charcoal-50">
-                <tr>
+      {infiniteQueryResponse?.hasResults && (
+        <>
+          <table className="min-w-full divide-y divide-charcoal-100">
+            <thead className="bg-charcoal-50">
+              <tr>
+                <th scope="col" className={headerClass}>
+                  <span className="sr-only">Is Selected</span>
+                </th>
+                <th scope="col" className={headerClass}>
+                  {isMultiDocType
+                    ? 'Language Entry'
+                    : getFriendlyDocType({ docType: types[0] })}
+                </th>
+                <th scope="col" className={headerClass}>
+                  Translation
+                </th>
+                {isMultiDocType ? (
                   <th scope="col" className={headerClass}>
-                    <span className="sr-only">Is Selected</span>
+                    Type
                   </th>
-                  <th scope="col" className={headerClass}>
-                    {isMultiDocType
-                      ? 'Language Entry'
-                      : getFriendlyDocType({ docType: types[0] })}
-                  </th>
-                  <th scope="col" className={headerClass}>
-                    Translation
-                  </th>
-                  {isMultiDocType ? (
-                    <th scope="col" className={headerClass}>
-                      Type
-                    </th>
-                  ) : null}
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-charcoal-100 space-y-2">
-                {searchResults?.pages?.map((page) => (
-                  <Fragment key={page.pageNumber}>
-                    {page.results.map((entry) => {
-                      // If an entry is already in the related_entries on the form
-                      // or if it is the entry currently being edited
-                      // it will not be included in the results
-                      if (
-                        formEntries?.some(
-                          (formEntry) => formEntry?.id === entry?.id,
-                        ) ||
-                        entry?.id === entryId
-                      ) {
-                        return null
-                      }
-                      const isSelected = selectedItems?.some(
-                        (elem) => elem?.id === entry?.id,
-                      )
-                      return (
-                        <tr
-                          key={entry.id}
-                          data-testid="SelectorEntriesRow"
-                          onClick={() => handleSelectAdditionalItems(entry)}
-                          className={
-                            isSelected
-                              ? 'ring-2 ring-jade-500 rounded-lg'
-                              : 'focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-offset-charcoal-50 focus-within:ring-blumine-800 rounded-lg'
-                          }
-                        >
-                          <td className="px-2 py-2 overflow-visible w-10 text-sm text-charcoal-900">
-                            {isSelected &&
-                              getIcon(
-                                'CheckCircleSolid',
-                                'h-6 w-6 fill-jade-500',
-                              )}
-                          </td>
-                          <td className="px-2 py-2 text-left overflow-visible w-80 text-sm text-charcoal-900">
-                            {entry.title}
-                          </td>
-                          <td className="px-6 py-4 text-left whitespace-normal text-sm text-charcoal-900">
-                            {entry?.translations ? (
-                              <ol className="text-charcoal-900">
-                                {entry.translations.map((translation, i) => (
-                                  <li key={translation?.text}>
-                                    {entry.translations.length > 1
-                                      ? `${i + 1}. `
-                                      : null}{' '}
-                                    {translation?.text}
-                                  </li>
-                                ))}
-                              </ol>
-                            ) : null}
-                          </td>
-                          {isMultiDocType ? (
-                            <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900 text-left">
-                              <span
-                                className={`px-2 inline-flex text-xs leading-5 font-medium rounded-full bg-${entry.type}-color-700 capitalize text-white`}
-                              >
-                                {entry.type}
-                              </span>
-                            </td>
+                ) : null}
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-charcoal-100 space-y-2">
+              {infiniteQueryResponse?.data?.pages?.map((page) => (
+                <Fragment key={page.pageNumber}>
+                  {page.results.map((entry) => {
+                    // If an entry is already in the related_entries on the form
+                    // or if it is the entry currently being edited
+                    // it will not be included in the results
+                    if (
+                      formEntries?.some(
+                        (formEntry) => formEntry?.id === entry?.id,
+                      ) ||
+                      entry?.id === entryId
+                    ) {
+                      return null
+                    }
+                    const isSelected = selectedItems?.some(
+                      (elem) => elem?.id === entry?.id,
+                    )
+                    return (
+                      <tr
+                        key={entry.id}
+                        data-testid="SelectorEntriesRow"
+                        onClick={() => handleSelectAdditionalItems(entry)}
+                        className={
+                          isSelected
+                            ? 'ring-2 ring-jade-500 rounded-lg'
+                            : 'focus-within:ring-2 focus-within:ring-offset-1 focus-within:ring-offset-charcoal-50 focus-within:ring-blumine-800 rounded-lg'
+                        }
+                      >
+                        <td className="px-2 py-2 overflow-visible w-10 text-sm text-charcoal-900">
+                          {isSelected &&
+                            getIcon(
+                              'CheckCircleSolid',
+                              'h-6 w-6 fill-jade-500',
+                            )}
+                        </td>
+                        <td className="px-2 py-2 text-left overflow-visible w-80 text-sm text-charcoal-900">
+                          {entry.title}
+                        </td>
+                        <td className="px-6 py-4 text-left whitespace-normal text-sm text-charcoal-900">
+                          {entry?.translations ? (
+                            <ol className="text-charcoal-900">
+                              {entry.translations.map((translation, i) => (
+                                <li key={translation?.text}>
+                                  {entry.translations.length > 1
+                                    ? `${i + 1}. `
+                                    : null}{' '}
+                                  {translation?.text}
+                                </li>
+                              ))}
+                            </ol>
                           ) : null}
-                        </tr>
-                      )
-                    })}
-                  </Fragment>
-                ))}
-              </tbody>
-            </table>
-            <div className="pt-10 text-center text-charcoal-900 font-medium print:hidden">
-              <button
-                data-testid="load-btn"
-                type="button"
-                className={!hasNextPage ? 'cursor-text' : ''}
-                onClick={() => fetchNextPage()}
-                disabled={!hasNextPage || isFetchingNextPage}
-              >
-                {loadLabel}
-              </button>
-            </div>
-          </>
-        )}
+                        </td>
+                        {isMultiDocType ? (
+                          <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900 text-left">
+                            <span
+                              className={`px-2 inline-flex text-xs leading-5 font-medium rounded-full bg-${entry.type}-color-700 capitalize text-white`}
+                            >
+                              {entry.type}
+                            </span>
+                          </td>
+                        ) : null}
+                      </tr>
+                    )
+                  })}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+          <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
+        </>
+      )}
     </div>
   )
 }
@@ -142,9 +128,8 @@ function SelectorEntriesPresentationList({
 const { array, arrayOf, func, object, string } = PropTypes
 
 SelectorEntriesPresentationList.propTypes = {
+  infiniteQueryResponse: object,
   formEntries: array,
-  searchResults: object,
-  infiniteScroll: object,
   selectedItems: object,
   handleSelectAdditionalItems: func,
   types: arrayOf(string),

--- a/src/components/SelectorImages/SelectorImagesContainer.js
+++ b/src/components/SelectorImages/SelectorImagesContainer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import SelectorSearchbox from 'components/SelectorSearchbox'
 import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 import SelectorVisualMediaGrid from 'components/SelectorVisualMediaGrid'
-import useMediaSearch from 'common/dataHooks/useMediaSearch'
+import useMediaSearchModal from 'common/dataHooks/useMediaSearchModal'
 import { TYPE_IMAGE } from 'common/constants'
 import RadioButtonGroup from 'components/RadioButtonGroup'
 
@@ -19,21 +19,19 @@ function SelectorImagesContainer({
 
   const {
     data,
-    searchValue,
+    displayedSearchTerm,
     handleSearchSubmit,
-    handleTextFieldChange,
+    handleSearchTermChange,
+    hasResults,
     infiniteScroll,
     isPending,
     loadRef,
     loadLabel,
-  } = useMediaSearch({
+  } = useMediaSearchModal({
     type: TYPE_IMAGE,
     searchSharedMedia: searchSharedMedia === 'true',
   })
 
-  const hasResults = !!(
-    data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0
-  )
   const sharedMediaOptions = [
     { value: 'true', label: 'Shared Images' },
     { value: 'false', label: 'Your image library' },
@@ -47,10 +45,10 @@ function SelectorImagesContainer({
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleTextFieldChange}
+            onSearchChange={handleSearchTermChange}
             onSearchSubmit={handleSearchSubmit}
             searchPlaceholder="Search all images"
-            searchValue={searchValue}
+            searchValue={displayedSearchTerm}
           />
         </div>
         {!hideSharedMedia && (

--- a/src/components/SelectorImages/SelectorImagesContainer.js
+++ b/src/components/SelectorImages/SelectorImagesContainer.js
@@ -17,17 +17,7 @@ function SelectorImagesContainer({
 }) {
   const [searchSharedMedia, setSearchSharedMedia] = useState('false')
 
-  const {
-    data,
-    displayedSearchTerm,
-    handleSearchSubmit,
-    handleSearchTermChange,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-    loadLabel,
-  } = useMediaSearchModal({
+  const infiniteQueryResponse = useMediaSearchModal({
     type: TYPE_IMAGE,
     searchSharedMedia: searchSharedMedia === 'true',
   })
@@ -45,10 +35,10 @@ function SelectorImagesContainer({
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleSearchTermChange}
-            onSearchSubmit={handleSearchSubmit}
+            onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+            onSearchSubmit={infiniteQueryResponse?.handleSearchSubmit}
             searchPlaceholder="Search all images"
-            searchValue={displayedSearchTerm}
+            searchValue={infiniteQueryResponse?.displayedSearchTerm}
           />
         </div>
         {!hideSharedMedia && (
@@ -63,9 +53,7 @@ function SelectorImagesContainer({
         )}
         <div className="grow h-72 overflow-y-scroll">
           <SelectorResultsWrapper.Presentation
-            hasResults={hasResults}
-            isLoading={isPending}
-            loadRef={loadRef}
+            infiniteQueryResponse={infiniteQueryResponse}
             resultsSection={
               <div aria-labelledby="results-header">
                 <div className="py-4 px-6 text-left">
@@ -84,9 +72,7 @@ function SelectorImagesContainer({
                   </p>
                 </div>
                 <SelectorVisualMediaGrid.Presentation
-                  data={data}
-                  infiniteScroll={infiniteScroll}
-                  loadLabel={loadLabel}
+                  infiniteQueryResponse={infiniteQueryResponse}
                   formMedia={formMedia}
                   selectedMedia={selectedMedia}
                   mediaSelectHandler={mediaSelectHandler}

--- a/src/components/SelectorResultsWrapper/SelectorResultsWrapperPresentation.js
+++ b/src/components/SelectorResultsWrapper/SelectorResultsWrapperPresentation.js
@@ -2,44 +2,35 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
-import Loading from 'components/Loading'
+import LoadOrError from 'components/LoadOrError'
 
 function SelectorResultsWrapperPresentation({
-  hasResults,
+  infiniteQueryResponse,
   resultsSection,
-  isLoading,
-  loadRef,
 }) {
   return (
-    <Loading.Container
+    <LoadOrError
       data-testid="SelectorResultsWrapperPresentation"
-      isLoading={isLoading}
+      queryResponse={infiniteQueryResponse}
       height="h-96"
     >
-      {hasResults && (
-        <div>
-          {resultsSection}
-          <div ref={loadRef} className="w-full h-10" />
-        </div>
-      )}
-      {!hasResults && (
+      {infiniteQueryResponse?.hasResults && <div>{resultsSection}</div>}
+      {!infiniteQueryResponse?.hasResults && (
         <div className="w-full min-h-screen flex col-span-1 md:col-span-3 xl:col-span-4">
           <div className="mx-6 mt-4 text-lg text-center md:mx-auto md:mt-20">
             Sorry, there are no results for this search.
           </div>
         </div>
       )}
-    </Loading.Container>
+    </LoadOrError>
   )
 }
 
 // PROPTYPES
-const { bool, node, object } = PropTypes
+const { node, object } = PropTypes
 SelectorResultsWrapperPresentation.propTypes = {
-  hasResults: bool,
   resultsSection: node,
-  isLoading: bool,
-  loadRef: object,
+  infiniteQueryResponse: object,
 }
 
 export default SelectorResultsWrapperPresentation

--- a/src/components/SelectorVideos/SelectorVideosContainer.js
+++ b/src/components/SelectorVideos/SelectorVideosContainer.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import SelectorSearchbox from 'components/SelectorSearchbox'
 import SelectorResultsWrapper from 'components/SelectorResultsWrapper'
 import SelectorVisualMediaGrid from 'components/SelectorVisualMediaGrid'
-import useMediaSearch from 'common/dataHooks/useMediaSearch'
+import useMediaSearchModal from 'common/dataHooks/useMediaSearchModal'
 import { TYPE_VIDEO } from 'common/constants'
 
 function SelectorVideosContainer({
@@ -15,18 +15,15 @@ function SelectorVideosContainer({
 }) {
   const {
     data,
-    searchValue,
+    displayedSearchTerm,
     handleSearchSubmit,
-    handleTextFieldChange,
+    handleSearchTermChange,
+    hasResults,
     infiniteScroll,
     isPending,
     loadRef,
     loadLabel,
-  } = useMediaSearch({ type: TYPE_VIDEO })
-
-  const hasResults = !!(
-    data?.pages !== undefined && data?.pages?.[0]?.results?.length > 0
-  )
+  } = useMediaSearchModal({ type: TYPE_VIDEO })
 
   return (
     <div
@@ -36,10 +33,10 @@ function SelectorVideosContainer({
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleTextFieldChange}
+            onSearchChange={handleSearchTermChange}
             onSearchSubmit={handleSearchSubmit}
             searchPlaceholder="Search all videos"
-            searchValue={searchValue}
+            searchValue={displayedSearchTerm}
           />
         </div>
         <div className="grow mt-2 h-72 overflow-y-scroll">

--- a/src/components/SelectorVideos/SelectorVideosContainer.js
+++ b/src/components/SelectorVideos/SelectorVideosContainer.js
@@ -13,17 +13,7 @@ function SelectorVideosContainer({
   selectedMedia,
   mediaSelectHandler,
 }) {
-  const {
-    data,
-    displayedSearchTerm,
-    handleSearchSubmit,
-    handleSearchTermChange,
-    hasResults,
-    infiniteScroll,
-    isPending,
-    loadRef,
-    loadLabel,
-  } = useMediaSearchModal({ type: TYPE_VIDEO })
+  const infiniteQueryResponse = useMediaSearchModal({ type: TYPE_VIDEO })
 
   return (
     <div
@@ -33,26 +23,22 @@ function SelectorVideosContainer({
       <div className="h-full w-full flex flex-col">
         <div className="w-3/4 mx-auto">
           <SelectorSearchbox.Presentation
-            onSearchChange={handleSearchTermChange}
-            onSearchSubmit={handleSearchSubmit}
+            onSearchChange={infiniteQueryResponse?.handleSearchTermChange}
+            onSearchSubmit={infiniteQueryResponse?.handleSearchSubmit}
             searchPlaceholder="Search all videos"
-            searchValue={displayedSearchTerm}
+            searchValue={infiniteQueryResponse?.displayedSearchTerm}
           />
         </div>
         <div className="grow mt-2 h-72 overflow-y-scroll">
           <SelectorResultsWrapper.Presentation
-            hasResults={hasResults}
-            isLoading={isPending}
-            loadRef={loadRef}
+            infiniteQueryResponse={infiniteQueryResponse}
             resultsSection={
               <div aria-labelledby="results-header">
                 <h2 id="results-header" className="sr-only">
                   Videos
                 </h2>
                 <SelectorVisualMediaGrid.Presentation
-                  data={data}
-                  infiniteScroll={infiniteScroll}
-                  loadLabel={loadLabel}
+                  infiniteQueryResponse={infiniteQueryResponse}
                   formMedia={formMedia}
                   selectedMedia={selectedMedia}
                   mediaSelectHandler={mediaSelectHandler}

--- a/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
+++ b/src/components/SelectorVisualMediaGrid/SelectorVisualMediaGridPresentation.js
@@ -5,16 +5,14 @@ import PropTypes from 'prop-types'
 import getIcon from 'common/utils/getIcon'
 import { SMALL, IMAGE } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function SelectorVisualMediaGridPresentation({
-  data,
-  infiniteScroll,
-  loadLabel,
+  infiniteQueryResponse,
   formMedia,
   selectedMedia,
   mediaSelectHandler,
 }) {
-  const { isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteScroll
   return (
     <div
       data-testid="SelectorVisualMediaGridPresentation"
@@ -22,9 +20,8 @@ function SelectorVisualMediaGridPresentation({
     >
       <div className="h-3/4 overflow-y-auto">
         <ul className="p-2 grid grid-cols-4 gap-y-8 gap-x-6 xl:gap-x-8">
-          {data?.pages !== undefined &&
-            data?.pages?.[0]?.results?.length > 0 &&
-            data?.pages?.map((page) => (
+          {infiniteQueryResponse?.hasResults &&
+            infiniteQueryResponse?.data?.pages?.map((page) => (
               <React.Fragment key={page?.pageNumber}>
                 {page.results.map((mediaObject) => {
                   if (formMedia?.some((elem) => elem?.id === mediaObject?.id)) {
@@ -87,28 +84,16 @@ function SelectorVisualMediaGridPresentation({
               </React.Fragment>
             ))}
         </ul>
-        <div className="pt-10 text-center text-charcoal-900 font-medium">
-          <button
-            data-testid="load-btn"
-            type="button"
-            className={!hasNextPage ? 'cursor-text' : ''}
-            onClick={() => fetchNextPage()}
-            disabled={!hasNextPage || isFetchingNextPage}
-          >
-            {loadLabel}
-          </button>
-        </div>
+        <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
       </div>
     </div>
   )
 }
 
 // PROPTYPES
-const { array, func, object, string } = PropTypes
+const { array, func, object } = PropTypes
 SelectorVisualMediaGridPresentation.propTypes = {
-  data: object,
-  infiniteScroll: object,
-  loadLabel: string,
+  infiniteQueryResponse: object,
   formMedia: array,
   selectedMedia: array,
   mediaSelectHandler: func,

--- a/src/components/SongsAndStories/SongsAndStoriesPresentation.js
+++ b/src/components/SongsAndStories/SongsAndStoriesPresentation.js
@@ -11,6 +11,7 @@ import Story from 'components/Story'
 import SongsAndStoriesGrid from 'components/SongsAndStories/SongsAndStoriesGrid'
 import SongsAndStoriesList from 'components/SongsAndStories/SongsAndStoriesList'
 import LoadOrError from 'components/LoadOrError'
+import InfiniteLoadBtn from 'components/InfiniteLoadBtn'
 
 function SongsAndStoriesPresentation({ infiniteQueryResponse, kids, labels }) {
   const { sitename } = useParams()
@@ -79,29 +80,9 @@ function SongsAndStoriesPresentation({ infiniteQueryResponse, kids, labels }) {
                         handleItemClick={handleItemClick}
                       />
                     )}
-
-                    <div className="p-3 text-center text-charcoal-900 font-medium">
-                      <div
-                        ref={infiniteQueryResponse?.loadRef}
-                        className="w-full h-5"
-                      />
-                      <button
-                        data-testid="load-btn"
-                        type="button"
-                        className={
-                          !infiniteQueryResponse?.hasNextPage
-                            ? 'cursor-text'
-                            : ''
-                        }
-                        onClick={() => infiniteQueryResponse?.fetchNextPage()}
-                        disabled={
-                          !infiniteQueryResponse?.hasNextPage ||
-                          infiniteQueryResponse?.isFetchingNextPage
-                        }
-                      >
-                        {infiniteQueryResponse?.loadLabel}
-                      </button>
-                    </div>
+                    <InfiniteLoadBtn
+                      infiniteQueryResponse={infiniteQueryResponse}
+                    />
                   </div>
                 ) : (
                   <div className="w-full flex col-span-1 md:col-span-3 xl:col-span-4">


### PR DESCRIPTION
### Description of Changes

- expands use of LoadOrError to other components
- Separates media modal search from media url search
- Adds reusable InfiniteLoadBtn which also contains useInfiniteScroll hook call and the ref - provides a more consistent reliable infinite scroll.
- Reduced duplication in ByAlphabet, ByCategory, and Dictionary using a new DictionaryLinks component
- Reduced complexity in ByAlphabet, ByCategory by using separate filter components and separating Kids from regular

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
