### PR TITLE
FW-5464 add document display to stories

### DIFF
--- a/src/components/Story/StoryPresentation.js
+++ b/src/components/Story/StoryPresentation.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 // FPCC
 import AudioNative from 'components/AudioNative'
 import LazyLoader from 'components/LazyLoader'
+import RelatedDocumentsList from 'components/RelatedDocumentsList'
 import WysiwygBlock from 'components/WysiwygBlock'
 import { IMAGE, VIDEO, VIDEO_LINK, MEDIUM, ORIGINAL } from 'common/constants'
 import { getMediaPath } from 'common/utils/mediaHelpers'
@@ -268,6 +269,24 @@ function StoryPresentation({ entry }) {
                       </ul>
                     </div>
                   )}
+                </div>
+              </div>
+            </div>
+          </LazyLoader>
+        )}
+
+        {/* Related Documents */}
+        {entry?.relatedDocuments?.length > 0 && (
+          <LazyLoader key="related-documents">
+            <div className={blockStyling}>
+              <div className="w-full md:w-6/12 flex flex-col grow shrink">
+                <div
+                  className={`${blockBgStyling} flex-1 text-charcoal-900 rounded-t-lg rounded-b-none p-4 lg:p-10 space-y-5`}
+                >
+                  <h4 className={labelStyling}>Related Documents</h4>
+                  <RelatedDocumentsList.Presentation
+                    documents={entry?.relatedDocuments || []}
+                  />
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Description of Changes
- Adds a `RelatedDocumentsList` to `StoryPresentation` within its own LazyLoader box.

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
