### PR TITLE
FW-6573 hide related document header if no related documents

### DIFF
--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -223,12 +223,14 @@ function DictionaryDetailPresentation({
           </section>
           <section>
             {/* Related Documents */}
-            <div className="py-2 md:p-4">
-              <h4 className={labelStyling}>Related Documents</h4>
-              <RelatedDocumentsList.Presentation
-                documents={entry?.relatedDocuments || []}
-              />
-            </div>
+            {entry?.relatedDocuments?.length > 0 && (
+              <div className="py-2 md:p-4">
+                <h4 className={labelStyling}>Related Documents</h4>
+                <RelatedDocumentsList.Presentation
+                  documents={entry?.relatedDocuments || []}
+                />
+              </div>
+            )}
           </section>
         </div>
         {/* Pictures and Video */}

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -285,12 +285,14 @@ function DictionaryDetailPresentationDrawer({
             </div>
           )}
           {/* Related Documents */}
-          <div className="py-3">
-            <h4 className={labelStyling}>Related Documents</h4>
-            <RelatedDocumentsList.Presentation
-              documents={entry?.relatedDocuments || []}
-            />
-          </div>
+          {entry?.relatedDocuments.length > 0 && (
+            <div className="py-3">
+              <h4 className={labelStyling}>Related Documents</h4>
+              <RelatedDocumentsList.Presentation
+                documents={entry?.relatedDocuments || []}
+              />
+            </div>
+          )}
           {/* created and modified */}
           {isDashboard && (
             <div className="border-t text-sm">

--- a/src/components/Song/SongPresentation.js
+++ b/src/components/Song/SongPresentation.js
@@ -113,13 +113,15 @@ function SongPresentation({ entry }) {
               </div>
             )}
             {/* Related Documents */}
-            <div className="space-y-2 py-5">
-              <h4 className={labelStyling}>Related Documents</h4>
-              <RelatedDocumentsList.Presentation
-                documents={entry?.relatedDocuments || []}
-                labelStyling={labelStyling}
-              />
-            </div>
+            {entry?.relatedDocuments?.length > 0 && (
+              <div className="space-y-2 py-5">
+                <h4 className={labelStyling}>Related Documents</h4>
+                <RelatedDocumentsList.Presentation
+                  documents={entry?.relatedDocuments || []}
+                  labelStyling={labelStyling}
+                />
+              </div>
+            )}
             {hasMedia && (
               <div className="flex md:hidden mt-2">
                 {getMedia({


### PR DESCRIPTION
### Description of Changes
- Adds the missing `{entry?.relatedDocuments.length > 0 && (` checks to dictionary entries and songs

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
