### PR TITLE
FW-6624 retain visibility state when switching steps

### DIFF
--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -6,7 +6,7 @@ import * as yup from 'yup'
 import Form from 'components/Form'
 import DeleteButton from 'components/DeleteButton'
 import { getFriendlyType } from 'common/utils/stringHelpers'
-import { TYPE_WORD, TYPE_PHRASE, PUBLIC, WARNING } from 'common/constants'
+import { TYPE_WORD, TYPE_PHRASE, WARNING } from 'common/constants'
 import getIcon from 'common/utils/getIcon'
 import { definitions } from 'common/utils/validationHelpers'
 import useEditForm from 'common/hooks/useEditForm'
@@ -63,7 +63,7 @@ function DictionaryCrudPresentation({
     title: '',
     type: type || TYPE_WORD,
     translations: [],
-    visibility: PUBLIC,
+    visibility: '',
     includeInKids: 'true',
     includeInGames: 'true',
   }

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -1,4 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
+import { useWatch } from 'react-hook-form'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -18,25 +19,21 @@ function Visibility({
   const { checkIfAssistant } = useAuthCheck()
   const isAssistant = checkIfAssistant()
 
-  // ensure the default value is set only once
-  const [hasRendered, setHasRendered] = useState({ current: false })
+  const visibilityValue = useWatch({ control, name: 'visibility' })
 
   useEffect(() => {
-    if (!hasRendered) {
-      const defaultValue = isAssistant
-        ? TEAM
-        : site?.visibilityOptions?.[0]?.value
-      // set default value to match visibility options
+    const defaultValue = isAssistant
+      ? TEAM
+      : site?.visibilityOptions?.[0]?.value
+    // set default value to match visibility options
+    if (visibilityValue === undefined || visibilityValue === '') {
       resetField('visibility', { defaultValue })
-      setHasRendered({ current: true })
     }
-  }, [site?.visibilityOptions, isAssistant, resetField, hasRendered])
+  }, [site?.visibilityOptions, isAssistant, resetField, visibilityValue])
 
   const options = isAssistant
     ? formattedVisibilityOptions([TEAM])
     : site?.visibilityOptions
-
-  console.log('hasRendered', hasRendered)
 
   return (
     <Select

--- a/src/components/Form/Visibility.js
+++ b/src/components/Form/Visibility.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
@@ -18,17 +18,25 @@ function Visibility({
   const { checkIfAssistant } = useAuthCheck()
   const isAssistant = checkIfAssistant()
 
+  // ensure the default value is set only once
+  const [hasRendered, setHasRendered] = useState({ current: false })
+
   useEffect(() => {
-    const defaultValue = isAssistant
-      ? TEAM
-      : site?.visibilityOptions?.[0]?.value
-    // set default value to match visibility options
-    resetField('visibility', { defaultValue })
-  }, [site?.visibilityOptions, isAssistant, resetField])
+    if (!hasRendered) {
+      const defaultValue = isAssistant
+        ? TEAM
+        : site?.visibilityOptions?.[0]?.value
+      // set default value to match visibility options
+      resetField('visibility', { defaultValue })
+      setHasRendered({ current: true })
+    }
+  }, [site?.visibilityOptions, isAssistant, resetField, hasRendered])
 
   const options = isAssistant
     ? formattedVisibilityOptions([TEAM])
     : site?.visibilityOptions
+
+  console.log('hasRendered', hasRendered)
 
   return (
     <Select


### PR DESCRIPTION
### Description of Changes
- Moves the `defaultVisibility` check to `useEditForm`
- Removes the `resetField` code from the Visibility component

### Checklist

- [x] ~~README / documentation has been updated if needed~~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
