### PR TITLE
FW-6620 Undo splashboard button changes

### DIFF
--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -132,7 +132,7 @@ function AlphabetPresentationSelected({
           to={`/${sitename}/${
             kids ? 'kids/' : ''
           }alphabet/startsWith?${CHAR}=${title}&types=word`}
-          className="btn-primary btn-xl"
+          className="btn-contained text-base text-center"
         >
           <span>See all words starting with</span>
           <div className="mb-1 text-3xl font-bold">{title}</div>

--- a/src/components/AudioButton/AudioButton.js
+++ b/src/components/AudioButton/AudioButton.js
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types'
 import { useAudiobar } from 'context/AudiobarContext'
 import getIcon from 'common/utils/getIcon'
 
-function AudioButton({ audioArray, hoverTooltip }) {
+function AudioButton({
+  audioArray,
+  iconStyling = 'fill-current text-charcoal-500 hover:text-charcoal-900 m-1 h-10 w-10',
+  hoverTooltip,
+}) {
   const { setCurrentAudio } = useAudiobar()
 
   return audioArray?.map((audioObject) =>
@@ -13,11 +17,11 @@ function AudioButton({ audioArray, hoverTooltip }) {
       <button
         type="button"
         key={audioObject?.id}
-        className="btn-tertiary btn-md-icon"
+        className="print:hidden relative group"
         onClick={() => setCurrentAudio(audioObject)}
       >
         <div className="sr-only">Play audio</div>
-        {getIcon('Audio')}
+        {getIcon('Audio', iconStyling)}
         {hoverTooltip ? (
           <div className="z-10 hidden group-hover:inline-flex absolute -bottom-8 -right-1 w-auto p-1 text-sm bg-charcoal-500 text-white text-center rounded-lg whitespace-nowrap">
             Play audio


### PR DESCRIPTION
### Description of Changes
Undo the splashboard button changes in the original 6620 PR for button consistency upon release.

### Checklist

- [x] ~~README / documentation has been updated if needed~~
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
