### PR TITLE
FW-6400-infinite-scroll-edit-speakers-again

### DIFF
--- a/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
@@ -23,48 +23,56 @@ function DashboardSpeakersPresentation({
         headerContent={headerContent}
         site={site}
       >
-        <DashboardTable.Presentation
-          queryResponse={infiniteQueryResponse}
-          title="Speakers"
-          tableHead={
-            <tr>
-              <th scope="col" className={tableHeaderClass}>
-                Name
-              </th>
-              <th scope="col" className={tableHeaderClass}>
-                Bio
-              </th>
-              {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
-              <th scope="col" className={`relative ${tableHeaderClass}`}>
-                <span className="sr-only">Edit speaker</span>
-              </th>
-            </tr>
-          }
-          tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
-            <Fragment key={page.pageNumber}>
-              {page.results.map((speaker) => (
-                <tr key={speaker.id}>
-                  <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
-                    {speaker.name}
-                  </td>
-                  <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
-                    {speaker?.bio || '-'}
-                  </td>
-                  <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
-                    <Link
-                      data-testid={`edit-speaker-${speaker.name}`}
-                      to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
-                      className="btn-tertiary btn-md-icon mr-6"
-                    >
-                      {getIcon('Pencil')}
-                    </Link>
-                  </td>
+        {infiniteQueryResponse?.hasResults && (
+          <div>
+            <DashboardTable.Presentation
+              queryResponse={infiniteQueryResponse}
+              title="Speakers"
+              tableHead={
+                <tr>
+                  <th scope="col" className={tableHeaderClass}>
+                    Name
+                  </th>
+                  <th scope="col" className={tableHeaderClass}>
+                    Bio
+                  </th>
+                  {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
+                  <th scope="col" className={`relative ${tableHeaderClass}`}>
+                    <span className="sr-only">Edit speaker</span>
+                  </th>
                 </tr>
+              }
+              tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
+                <Fragment key={page.pageNumber}>
+                  {page.results.map((speaker) => (
+                    <tr key={speaker?.id}>
+                      <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
+                        {speaker?.name}
+                      </td>
+                      <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
+                        {speaker?.bio || '-'}
+                      </td>
+                      <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <Link
+                          data-testid={`edit-speaker-${speaker?.name}`}
+                          to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
+                          className="btn-tertiary btn-md-icon mr-6"
+                        >
+                          {getIcon('Pencil')}
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
               ))}
-              <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
-            </Fragment>
-          ))}
-        />
+              infiniteLoadBtn={
+                <InfiniteLoadBtn
+                  infiniteQueryResponse={infiniteQueryResponse}
+                />
+              }
+            />
+          </div>
+        )}
       </DashboardLanding.Presentation>
     </div>
   )

--- a/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
@@ -23,52 +23,50 @@ function DashboardSpeakersPresentation({
         headerContent={headerContent}
         site={site}
       >
-        {infiniteQueryResponse?.hasResults && (
-          <DashboardTable.Presentation
-            queryResponse={infiniteQueryResponse}
-            title="Speakers"
-            tableHead={
-              <tr>
-                <th scope="col" className={tableHeaderClass}>
-                  Name
-                </th>
-                <th scope="col" className={tableHeaderClass}>
-                  Bio
-                </th>
-                {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
-                <th scope="col" className={`relative ${tableHeaderClass}`}>
-                  <span className="sr-only">Edit speaker</span>
-                </th>
-              </tr>
-            }
-            tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
-              <Fragment key={page.pageNumber}>
-                {page.results.map((speaker) => (
-                  <tr key={speaker?.id}>
-                    <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
-                      {speaker?.name}
-                    </td>
-                    <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
-                      {speaker?.bio || '-'}
-                    </td>
-                    <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <Link
-                        data-testid={`edit-speaker-${speaker?.name}`}
-                        to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
-                        className="btn-tertiary btn-md-icon mr-6"
-                      >
-                        {getIcon('Pencil')}
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </Fragment>
-            ))}
-            infiniteLoadBtn={
-              <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
-            }
-          />
-        )}
+        <DashboardTable.Presentation
+          queryResponse={infiniteQueryResponse}
+          title="Speakers"
+          tableHead={
+            <tr>
+              <th scope="col" className={tableHeaderClass}>
+                Name
+              </th>
+              <th scope="col" className={tableHeaderClass}>
+                Bio
+              </th>
+              {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
+              <th scope="col" className={`relative ${tableHeaderClass}`}>
+                <span className="sr-only">Edit speaker</span>
+              </th>
+            </tr>
+          }
+          tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
+            <Fragment key={page.pageNumber}>
+              {page.results.map((speaker) => (
+                <tr key={speaker?.id}>
+                  <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
+                    {speaker?.name}
+                  </td>
+                  <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
+                    {speaker?.bio || '-'}
+                  </td>
+                  <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <Link
+                      data-testid={`edit-speaker-${speaker?.name}`}
+                      to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
+                      className="btn-tertiary btn-md-icon mr-6"
+                    >
+                      {getIcon('Pencil')}
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </Fragment>
+          ))}
+          infiniteLoadBtn={
+            <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
+          }
+        />
       </DashboardLanding.Presentation>
     </div>
   )

--- a/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
+++ b/src/components/DashboardSpeakers/DashboardSpeakersPresentation.js
@@ -24,54 +24,50 @@ function DashboardSpeakersPresentation({
         site={site}
       >
         {infiniteQueryResponse?.hasResults && (
-          <div>
-            <DashboardTable.Presentation
-              queryResponse={infiniteQueryResponse}
-              title="Speakers"
-              tableHead={
-                <tr>
-                  <th scope="col" className={tableHeaderClass}>
-                    Name
-                  </th>
-                  <th scope="col" className={tableHeaderClass}>
-                    Bio
-                  </th>
-                  {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
-                  <th scope="col" className={`relative ${tableHeaderClass}`}>
-                    <span className="sr-only">Edit speaker</span>
-                  </th>
-                </tr>
-              }
-              tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
-                <Fragment key={page.pageNumber}>
-                  {page.results.map((speaker) => (
-                    <tr key={speaker?.id}>
-                      <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
-                        {speaker?.name}
-                      </td>
-                      <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
-                        {speaker?.bio || '-'}
-                      </td>
-                      <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
-                        <Link
-                          data-testid={`edit-speaker-${speaker?.name}`}
-                          to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
-                          className="btn-tertiary btn-md-icon mr-6"
-                        >
-                          {getIcon('Pencil')}
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
-                </Fragment>
-              ))}
-              infiniteLoadBtn={
-                <InfiniteLoadBtn
-                  infiniteQueryResponse={infiniteQueryResponse}
-                />
-              }
-            />
-          </div>
+          <DashboardTable.Presentation
+            queryResponse={infiniteQueryResponse}
+            title="Speakers"
+            tableHead={
+              <tr>
+                <th scope="col" className={tableHeaderClass}>
+                  Name
+                </th>
+                <th scope="col" className={tableHeaderClass}>
+                  Bio
+                </th>
+                {/* `relative` is added here due to a weird bug in Safari that causes `sr-only` headings to introduce overflow on the body on mobile. */}
+                <th scope="col" className={`relative ${tableHeaderClass}`}>
+                  <span className="sr-only">Edit speaker</span>
+                </th>
+              </tr>
+            }
+            tableBody={infiniteQueryResponse?.data?.pages?.map((page) => (
+              <Fragment key={page.pageNumber}>
+                {page.results.map((speaker) => (
+                  <tr key={speaker?.id}>
+                    <td className="px-6 py-4 whitespace-normal text-sm font-medium text-charcoal-900">
+                      {speaker?.name}
+                    </td>
+                    <td className="px-6 py-4 whitespace-normal text-sm text-charcoal-900">
+                      {speaker?.bio || '-'}
+                    </td>
+                    <td className="px-1 py-4 whitespace-nowrap text-right text-sm font-medium">
+                      <Link
+                        data-testid={`edit-speaker-${speaker?.name}`}
+                        to={`/${site?.sitename}/dashboard/edit/speaker?id=${speaker?.id}`}
+                        className="btn-tertiary btn-md-icon mr-6"
+                      >
+                        {getIcon('Pencil')}
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </Fragment>
+            ))}
+            infiniteLoadBtn={
+              <InfiniteLoadBtn infiniteQueryResponse={infiniteQueryResponse} />
+            }
+          />
         )}
       </DashboardLanding.Presentation>
     </div>

--- a/src/components/DashboardTable/DashboardTablePresentation.js
+++ b/src/components/DashboardTable/DashboardTablePresentation.js
@@ -37,7 +37,7 @@ function DashboardTablePresentation({
                       {tableBody}
                     </tbody>
                   </table>
-                  {infiniteLoadBtn}
+                  {infiniteLoadBtn && <div>{infiniteLoadBtn}</div>}
                 </div>
               </div>
             </div>

--- a/src/components/DashboardTable/DashboardTablePresentation.js
+++ b/src/components/DashboardTable/DashboardTablePresentation.js
@@ -3,13 +3,14 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import LoadOrError from 'components/LoadOrError'
-
 function DashboardTablePresentation({
   title,
   queryResponse,
   tableHead,
   tableBody,
+  infiniteLoadBtn,
 }) {
+  console.log({ queryResponse })
   return (
     <LoadOrError queryResponse={queryResponse}>
       <section
@@ -37,6 +38,7 @@ function DashboardTablePresentation({
                       {tableBody}
                     </tbody>
                   </table>
+                  {infiniteLoadBtn}
                 </div>
               </div>
             </div>
@@ -53,6 +55,7 @@ DashboardTablePresentation.propTypes = {
   tableHead: node,
   tableBody: node,
   title: string,
+  infiniteLoadBtn: node,
 }
 
 export default DashboardTablePresentation

--- a/src/components/DashboardTable/DashboardTablePresentation.js
+++ b/src/components/DashboardTable/DashboardTablePresentation.js
@@ -10,7 +10,6 @@ function DashboardTablePresentation({
   tableBody,
   infiniteLoadBtn,
 }) {
-  console.log({ queryResponse })
   return (
     <LoadOrError queryResponse={queryResponse}>
       <section

--- a/src/services/api/people.js
+++ b/src/services/api/people.js
@@ -4,8 +4,12 @@ import { SITES, PEOPLE } from 'common/constants'
 const people = {
   get: async ({ sitename, id }) =>
     apiBase().get(`${SITES}/${sitename}/${PEOPLE}/${id}`).json(),
-  getAll: async ({ sitename }) =>
-    apiBase().get(`${SITES}/${sitename}/${PEOPLE}/`).json(),
+  getAll: async ({ sitename, pageParam, perPage = 100 }) =>
+    apiBase()
+      .get(
+        `${SITES}/${sitename}/${PEOPLE}/?page=${pageParam}&pageSize=${perPage}`,
+      )
+      .json(),
   create: async ({ sitename, properties }) => {
     const body = {
       name: properties?.name,


### PR DESCRIPTION
### Description of Changes

reworked Dashboard Table to allow for infinite loading. Fixed bugs in edit speakers list to load next page

### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
