### PR TITLE
FW-6197: Add hyperlink functionality to tiptap editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.10",
         "@tanstack/react-query": "^5.62.16",
+        "@tiptap/extension-link": "^2.12.0",
         "@tiptap/pm": "^2.12.0",
         "@tiptap/react": "^2.12.0",
         "@tiptap/starter-kit": "^2.12.0",
@@ -4178,6 +4179,23 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.14.0.tgz",
+      "integrity": "sha512-fsqW7eRD2xoD6xy7eFrNPAdIuZ3eicA4jKC45Vcft/Xky0DJoIehlVBLxsPbfmv3f27EBrtPkg5+msLXkLyzJA==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
@@ -11215,6 +11233,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.1.tgz",
+      "integrity": "sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==",
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "15.5.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.5.10",
     "@tanstack/react-query": "^5.62.16",
+    "@tiptap/extension-link": "^2.12.0",
     "@tiptap/react": "^2.12.0",
     "@tiptap/pm": "^2.12.0",
     "@tiptap/starter-kit": "^2.12.0",

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -28,6 +28,9 @@
   .wysiwyg p {
     @apply my-4;
   }
+  .wysiwyg a {
+    @apply text-blue-600 visited:text-purple-600 underline underline-offset-2;
+  }
 }
 
 /* Prevent blue focus outline in tiptap editor */

--- a/src/components/Form/WysiwygControls/InlineStyleToolbar.js
+++ b/src/components/Form/WysiwygControls/InlineStyleToolbar.js
@@ -1,10 +1,22 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 
 // FPCC
 import Button from 'components/Form/WysiwygControls/Button'
+import getIcon from 'common/utils/getIcon'
 
 function InlineStyleToolbar({ editor }) {
+  const setLink = useCallback(() => {
+    const url = window.prompt(
+      'Enter a URL. To remove the link, leave it blank and click OK.',
+    )
+    if (url) {
+      editor.chain().focus().setLink({ href: url }).run()
+    } else {
+      editor.chain().focus().unsetLink().run()
+    }
+  }, [editor])
+
   return (
     <span className="flex border-b border-charcoal-100 text-xl text-charcoal-700">
       <Button
@@ -14,6 +26,10 @@ function InlineStyleToolbar({ editor }) {
       <Button
         onClickHandler={() => editor.chain().focus().toggleItalic().run()}
         label={<span className="italic">I</span>}
+      />
+      <Button
+        onClickHandler={setLink}
+        label={getIcon('Link', `w-5 h-5 fill-current`)}
       />
     </span>
   )

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { useController } from 'react-hook-form'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
 
 // FPCC
 import WysiwygControls from 'components/Form/WysiwygControls'
@@ -27,7 +28,12 @@ function WysiwygField({
   })
 
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [
+      StarterKit,
+      Link.configure({
+        defaultProtocol: 'https:',
+      }),
+    ],
     content: value,
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML())


### PR DESCRIPTION
### Description of Changes

- Adds the @tiptap/extension-link package for link support in tiptap
- Auto-creates links in the wysiwygfield with proper formatting when pasted into the field
- Adds a link button to the tiptap editor that allows uses to set text to a link

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
