### PR TITLE
FW-6197 Ensure links always open in new tab

### DIFF
--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -32,6 +32,11 @@ function WysiwygField({
       StarterKit,
       Link.configure({
         defaultProtocol: 'https:',
+        openOnClick: true,
+        HTMLAttributes: {
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        },
       }),
     ],
     content: value,

--- a/src/components/SanitizedHtml/SanitizedHtml.js
+++ b/src/components/SanitizedHtml/SanitizedHtml.js
@@ -9,12 +9,24 @@ DOMPurify.addHook('uponSanitizeElement', (node, data) => {
       return node.parentNode?.removeChild(node)
     }
   }
+
+  if (data.tagName === 'a') {
+    node.setAttribute('target', '_blank')
+    node.setAttribute('rel', 'noopener noreferrer')
+  }
 })
 
 const Sanitize = (content) =>
   DOMPurify.sanitize(content, {
     ADD_TAGS: ['iframe'],
-    ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+    ADD_ATTR: [
+      'allow',
+      'allowfullscreen',
+      'frameborder',
+      'scrolling',
+      'target',
+      'rel',
+    ],
   })
 
 function SanitizedHtml({ htmlString = '', className, tagName = 'div' }) {


### PR DESCRIPTION
### Description of Changes

- Adds `target: '_blank'` and `rel: 'noopener noreferrer'` specifications to both wysiwygField and wysiwygBlock

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
