### PR TITLE
FW-6462 Splashboard detail buttons

### DIFF
--- a/src/components/Actions/Copy.js
+++ b/src/components/Actions/Copy.js
@@ -9,7 +9,6 @@ function Copy({
   iconStyling = 'h-8 w-8 md:h-6 md:w-6',
   withLabels = false,
   withConfirmation = false,
-  withTooltip = false,
   hoverTooltip,
 }) {
   const [confirmation, setConfirmation] = useState(false)
@@ -24,13 +23,15 @@ function Copy({
     }
   }
 
+  const buttonClass = `relative group btn-tertiary ${withLabels ? ' btn-md' : 'btn-md-icon'}`
+
   return (
     <button
       type="button"
       id="CopyAction"
       data-testid={`copy-btn-${textToCopy}`}
       aria-label="Copy to clipboard"
-      className="relative inline-flex items-center text-sm font-medium text-charcoal-900 hover:text-black group"
+      className={buttonClass}
       onClick={() =>
         copyToClipboard({ text: textToCopy, confirmationCallback })
       }
@@ -38,23 +39,13 @@ function Copy({
       {getIcon('Copy', `fill-current ${iconStyling}`)}
       {hoverTooltip ? (
         <div className="z-10 hidden group-hover:inline-flex absolute -bottom-8 -right-1 w-auto p-1 text-sm bg-charcoal-500 text-white text-center rounded-lg">
-          Copy
+          {confirmation ? 'Copied' : 'Copy'}
         </div>
       ) : null}
       {withLabels ? (
         <>
-          <span className="mx-2">COPY</span>
-          <span className={confirmation ? '' : 'hidden'}>
-            <span className="absolute bottom-1 -right-1 bg-white">COPIED</span>
-          </span>
+          <span className="mx-2">{confirmation ? 'COPIED' : 'COPY'}</span>
         </>
-      ) : null}
-      {withTooltip ? (
-        <span className={confirmation ? '' : 'hidden'}>
-          <div className="absolute bottom-0 -right-1 w-auto p-1 text-sm bg-charcoal-500 text-white text-center rounded-lg shadow-lg ">
-            Copied
-          </div>
-        </span>
       ) : null}
     </button>
   )

--- a/src/components/Actions/Copy.js
+++ b/src/components/Actions/Copy.js
@@ -57,7 +57,6 @@ Copy.propTypes = {
   iconStyling: string,
   withLabels: bool,
   withConfirmation: bool,
-  withTooltip: bool,
   hoverTooltip: bool,
 }
 

--- a/src/components/Actions/Copy.js
+++ b/src/components/Actions/Copy.js
@@ -43,9 +43,7 @@ function Copy({
         </div>
       ) : null}
       {withLabels ? (
-        <>
-          <span className="mx-2">{confirmation ? 'COPIED' : 'COPY'}</span>
-        </>
+        <span className="mx-2">{confirmation ? 'COPIED' : 'COPY'}</span>
       ) : null}
     </button>
   )

--- a/src/components/ActionsMenu/ActionsMenuPresentation.js
+++ b/src/components/ActionsMenu/ActionsMenuPresentation.js
@@ -22,7 +22,6 @@ function ActionsMenuPresentation({
   iconStyling = 'h-8 w-8 md:h-6 md:w-6',
   withLabels,
   withConfirmation,
-  withTooltip,
 }) {
   const moreButtonClassName = `relative btn-tertiary ${withLabels ? 'btn-md' : 'btn-md-icon'}`
   return (
@@ -37,7 +36,6 @@ function ActionsMenuPresentation({
           iconStyling={iconStyling}
           withLabels={withLabels}
           withConfirmation={withConfirmation}
-          withTooltip={withTooltip}
           hoverTooltip
         />
       ) : null}

--- a/src/components/ActionsMenu/ActionsMenuPresentation.js
+++ b/src/components/ActionsMenu/ActionsMenuPresentation.js
@@ -24,8 +24,12 @@ function ActionsMenuPresentation({
   withConfirmation,
   withTooltip,
 }) {
+  const moreButtonClassName = `relative btn-tertiary ${withLabels ? 'btn-md' : 'btn-md-icon'}`
   return (
-    <div id="ActionsMenuPresentation" className="inline-flex print:hidden">
+    <div
+      id="ActionsMenuPresentation"
+      className="inline-flex items-center print:hidden"
+    >
       {/* Pinned Action Buttons */}
       {actions.includes('copy') ? (
         <Copy
@@ -37,6 +41,12 @@ function ActionsMenuPresentation({
           hoverTooltip
         />
       ) : null}
+
+      {/* Divider */}
+      {moreActions.length > 0 ? (
+        <div className="w-px h-9 m-1 bg-charcoal-200" aria-hidden="true" />
+      ) : null}
+
       {/* More Menu button and Action items */}
       {moreActions.length > 0 ? (
         <Menu as="div" className="relative inline-flex text-left">
@@ -45,7 +55,7 @@ function ActionsMenuPresentation({
               <MenuButton
                 id="More"
                 aria-label="More Options"
-                className="ml-2 pl-2 relative inline-flex items-center text-sm font-medium text-charcoal-900 hover:text-black border-l border-charcoal-200"
+                className={moreButtonClassName}
               >
                 {getIcon('More', `fill-current ${iconStyling}`)}
                 {withLabels ? <span className="mx-2">MORE</span> : null}

--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -40,11 +40,7 @@ function AlphabetPresentationSelected({
       >
         {title}
         {relatedAudio?.length > 0 && (
-          <AudioButton
-            audioArray={relatedAudio}
-            iconStyling="fill-current h-6 w-6 sm:w-8 sm:h-8 ml-2"
-            hoverTooltip
-          />
+          <AudioButton audioArray={relatedAudio} hoverTooltip />
         )}
         {title ? (
           <Copy
@@ -92,7 +88,6 @@ function AlphabetPresentationSelected({
                     {word?.relatedAudio?.length > 0 && (
                       <AudioButton
                         audioArray={word?.relatedAudio}
-                        iconStyling="fill-current h-6 w-6 sm:w-8 sm:h-8 ml-2"
                         hoverTooltip
                       />
                     )}

--- a/src/components/Alphabet/AlphabetPresentationSelected.js
+++ b/src/components/Alphabet/AlphabetPresentationSelected.js
@@ -51,7 +51,6 @@ function AlphabetPresentationSelected({
             textToCopy={title}
             iconStyling="fill-current text-blumine-800 h-6 w-6 sm:w-8 sm:h-8 ml-2"
             withConfirmation
-            withTooltip
             hoverTooltip
           />
         ) : null}

--- a/src/components/AudioButton/AudioButton.js
+++ b/src/components/AudioButton/AudioButton.js
@@ -5,11 +5,7 @@ import PropTypes from 'prop-types'
 import { useAudiobar } from 'context/AudiobarContext'
 import getIcon from 'common/utils/getIcon'
 
-function AudioButton({
-  audioArray,
-  iconStyling = 'fill-current text-charcoal-500 hover:text-charcoal-900 m-1 h-10 w-10',
-  hoverTooltip,
-}) {
+function AudioButton({ audioArray, hoverTooltip }) {
   const { setCurrentAudio } = useAudiobar()
 
   return audioArray?.map((audioObject) =>
@@ -22,7 +18,7 @@ function AudioButton({
         onClick={() => setCurrentAudio(audioObject)}
       >
         <div className="sr-only">Play audio</div>
-        {getIcon('Audio', `${iconStyling} -translate-x-1`)}
+        {getIcon('Audio', 'fill-current m-1 -translate-x-1')}
         {hoverTooltip ? (
           <div className="z-10 hidden group-hover:inline-flex absolute -bottom-8 -right-1 w-auto p-1 text-sm bg-charcoal-500 text-white text-center rounded-lg whitespace-nowrap">
             Play audio

--- a/src/components/AudioButton/AudioButton.js
+++ b/src/components/AudioButton/AudioButton.js
@@ -16,12 +16,13 @@ function AudioButton({
     audioObject?.id ? (
       <button
         type="button"
+        data-testid={`audio-btn-${audioObject.id}`}
         key={audioObject?.id}
-        className="print:hidden relative group"
+        className="btn-tertiary btn-md-icon relative group"
         onClick={() => setCurrentAudio(audioObject)}
       >
         <div className="sr-only">Play audio</div>
-        {getIcon('Audio', iconStyling)}
+        {getIcon('Audio', `${iconStyling} -translate-x-1`)}
         {hoverTooltip ? (
           <div className="z-10 hidden group-hover:inline-flex absolute -bottom-8 -right-1 w-auto p-1 text-sm bg-charcoal-500 text-white text-center rounded-lg whitespace-nowrap">
             Play audio

--- a/src/components/AudioMinimal/AudioMinimalPresentation.js
+++ b/src/components/AudioMinimal/AudioMinimalPresentation.js
@@ -6,17 +6,16 @@ import getIcon from 'common/utils/getIcon'
 
 function AudioMinimalPresentation({
   buttonRef,
-  buttonStyling = '',
+  buttonStyling = 'btn-tertiary btn-md-icon bg-inherit',
   icons,
-  iconStyling = 'fill-current w-7 h-7 lg:w-8 lg:h-8 xl:w-12 xl:h-12',
   isPlaying = false,
   label,
   onClick = () => {},
   onKeyPress = () => {},
 }) {
   const iconsDefault = {
-    Play: getIcon('PlayCircle', iconStyling),
-    Stop: getIcon('StopCircle', iconStyling),
+    Play: getIcon('PlayCircle'),
+    Stop: getIcon('StopCircle'),
   }
   const Icons = { ...iconsDefault, ...icons }
 

--- a/src/components/ByAlphabet/ByAlphabetFilters.js
+++ b/src/components/ByAlphabet/ByAlphabetFilters.js
@@ -23,10 +23,7 @@ function ByAlphabetFilters({
           {currentCharacter.title}
           {currentCharacter?.relatedAudio?.length > 0 && (
             <div className="ml-2">
-              <AudioButton
-                audioArray={currentCharacter?.relatedAudio}
-                iconStyling="fill-current h-8 w-8"
-              />
+              <AudioButton audioArray={currentCharacter?.relatedAudio} />
             </div>
           )}
         </div>

--- a/src/components/DashboardMediaDetails/DashboardMediaDetailsPresentation.js
+++ b/src/components/DashboardMediaDetails/DashboardMediaDetailsPresentation.js
@@ -69,12 +69,7 @@ function DashboardMediaDetailsPresentation({ file, mediaTypePath, thumbnail }) {
               <div className="py-3 grid grid-cols-3 gap-1 text-sm font-medium items-center">
                 <dt className="col-span-1 text-charcoal-500 capitalize truncate h-24 flex items-center">
                   ID
-                  <Copy
-                    textToCopy={file.id}
-                    withConfirmation
-                    withTooltip
-                    hoverTooltip
-                  />
+                  <Copy textToCopy={file.id} withConfirmation hoverTooltip />
                 </dt>
                 <dd className="col-span-2 text-charcoal-900">{file.id}</dd>
               </div>

--- a/src/components/DictionaryDetail/DictionaryDetailPresentation.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentation.js
@@ -129,7 +129,7 @@ function DictionaryDetailPresentation({
                         }`,
                       ),
                     }}
-                    buttonStyling="bg-scarlet-800 hover:bg-scarlet-900 text-white text-sm rounded-lg inline-flex items-center py-1.5 px-2 mr-2 my-1"
+                    buttonStyling="btn-primary btn-sm mr-2 my-1"
                     label={audioObject?.speakers?.[0]?.name}
                     audioObject={audioObject}
                   />

--- a/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
+++ b/src/components/DictionaryDetail/DictionaryDetailPresentationDrawer.js
@@ -106,7 +106,7 @@ function DictionaryDetailPresentationDrawer({
                         }`,
                       ),
                     }}
-                    buttonStyling="bg-scarlet-800 hover:bg-scarlet-900 text-white text-sm rounded-lg inline-flex items-center py-1.5 px-2 mr-2 my-2"
+                    buttonStyling="btn-primary btn-sm mr-2 my-2"
                     label={audioObject?.speakers?.[0]?.name}
                     audioObject={audioObject}
                   />

--- a/src/components/DictionaryGridTile/DictionaryGridTilePresentation.js
+++ b/src/components/DictionaryGridTile/DictionaryGridTilePresentation.js
@@ -41,7 +41,6 @@ function DictionaryGridTilePresentation({ actions, moreActions, entry }) {
               moreActions={moreActions}
               iconStyling="w-8 h-8"
               withConfirmation
-              withTooltip
             />
           </div>
           {/* Translations/Definitions */}

--- a/src/components/DictionaryList/DictionaryListPresentation.js
+++ b/src/components/DictionaryList/DictionaryListPresentation.js
@@ -141,7 +141,6 @@ function DictionaryListPresentation({
                                 <div className="inline-flex items-center">
                                   <AudioButton
                                     audioArray={entry?.audio}
-                                    iconStyling="fill-current text-charcoal-500 hover:text-charcoal-900 m-1 h-6 w-6"
                                     hoverTooltip
                                   />
                                 </div>

--- a/src/components/DictionaryList/DictionaryListPresentation.js
+++ b/src/components/DictionaryList/DictionaryListPresentation.js
@@ -203,7 +203,6 @@ function DictionaryListPresentation({
                                   actions={actions}
                                   moreActions={moreActions}
                                   withConfirmation
-                                  withTooltip
                                 />
                               </td>
                             </tr>

--- a/src/components/Drawer/DrawerPresentation.js
+++ b/src/components/Drawer/DrawerPresentation.js
@@ -30,22 +30,22 @@ function DrawerPresentation({
                   {fullScreenPath && (
                     <Link
                       data-testid="full-screen-link"
-                      className="text-charcoal-500 hover:text-charcoal-900"
+                      className="btn-tertiary btn-md-icon"
                       to={fullScreenPath}
                     >
                       <span className="sr-only">Full screen</span>
-                      {getIcon('Fullscreen', 'fill-current h-5 w-5')}
+                      {getIcon('Fullscreen', '-translate-x-1')}
                     </Link>
                   )}
                   <button
                     type="button"
                     id="CloseDrawerBtn"
                     data-testid="close-drawer-btn"
-                    className="text-charcoal-500 hover:text-charcoal-500"
+                    className="btn-tertiary btn-md-icon"
                     onClick={closeHandler}
                   >
                     <span className="sr-only">Close panel</span>
-                    {getIcon('Close', 'fill-current h-7 w-7')}
+                    {getIcon('Close', '-translate-x-1')}
                   </button>
                 </div>
                 {children}

--- a/src/components/Game/PhraseScrambler/PhraseScramblerPresentation.js
+++ b/src/components/Game/PhraseScrambler/PhraseScramblerPresentation.js
@@ -129,11 +129,7 @@ function PhraseScramblerPresentation({
                       Great Job!
                     </p>
                     {relatedAudio?.length > 0 && (
-                      <AudioButton
-                        audioArray={relatedAudio}
-                        iconStyling="inline fill-current text-charcoal-500 hover:text-charcoal-900 h-6 w-6 ml-2"
-                        hoverTooltip
-                      />
+                      <AudioButton audioArray={relatedAudio} hoverTooltip />
                     )}
                   </div>
                 )}
@@ -156,11 +152,7 @@ function PhraseScramblerPresentation({
                         <p className="inline align-center">
                           Need a hint? Listen to the phrase:
                         </p>
-                        <AudioButton
-                          audioArray={relatedAudio}
-                          iconStyling="inline fill-current text-charcoal-500 hover:text-charcoal-900 h-6 w-6"
-                          hoverTooltip
-                        />
+                        <AudioButton audioArray={relatedAudio} hoverTooltip />
                       </div>
                     )}
                   </div>

--- a/src/components/Immersion/ImmersionPresentationList.js
+++ b/src/components/Immersion/ImmersionPresentationList.js
@@ -63,7 +63,6 @@ function ImmersionPresentationList({ labels }) {
                           sitename={dictionaryEntry?.[0]?.sitename}
                           actions={['copy']}
                           withConfirmation
-                          withTooltip
                         />
                       </td>
                     </tr>

--- a/src/components/Immersion/ImmersionPresentationList.js
+++ b/src/components/Immersion/ImmersionPresentationList.js
@@ -49,11 +49,7 @@ function ImmersionPresentationList({ labels }) {
                           {immersionLabel}
                         </Link>
                         {relatedAudio?.length > 0 && (
-                          <AudioButton
-                            audioArray={relatedAudio}
-                            iconStyling="fill-current text-charcoal-500 hover:text-charcoal-900 m-1 h-8 w-8 md:h-6 md:w-6"
-                            hoverTooltip
-                          />
+                          <AudioButton audioArray={relatedAudio} hoverTooltip />
                         )}
                       </td>
                       <td className="px-6 py-4 text-charcoal-900">{english}</td>

--- a/src/components/Song/SongPresentationDrawer.js
+++ b/src/components/Song/SongPresentationDrawer.js
@@ -72,7 +72,7 @@ function SongPresentationDrawer({ entry, isDashboard }) {
           <div className="flex flex-wrap">
             <Link
               to={`/${entry?.site?.slug}/songs/${entry?.id}`}
-              className="btn-contained bg-song-color-900 shrink-0 w-full sm:flex-1"
+              className="btn-primary btn-md shrink-0 w-full"
             >
               <span className="whitespace-nowrap">Go to Song</span>
             </Link>

--- a/src/components/Story/StoryPresentationDrawer.js
+++ b/src/components/Story/StoryPresentationDrawer.js
@@ -85,7 +85,7 @@ function StoryPresentationDrawer({ entry, isDashboard }) {
           <div className="flex flex-wrap">
             <Link
               to={`/${entry?.site?.slug}/stories/${entry?.id}`}
-              className="btn-contained shrink-0 w-full bg-story-color-900 sm:flex-1"
+              className="btn-primary btn-md shrink-0 w-full"
             >
               <span className="whitespace-nowrap">Go to Story</span>
             </Link>

--- a/src/components/WidgetText/WidgetTextPresentation.js
+++ b/src/components/WidgetText/WidgetTextPresentation.js
@@ -76,13 +76,7 @@ function WidgetTextPresentation({ widgetData }) {
           } font-bold flex items-center mb-4`}
         >
           <span className="inline-block">{title}</span>
-          {audio && (
-            <AudioButton
-              audioArray={[audioObject]}
-              iconStyling="fill-current h-6 w-6 sm:w-8 sm:h-8 ml-2"
-              hoverTooltip
-            />
-          )}
+          {audio && <AudioButton audioArray={[audioObject]} hoverTooltip />}
         </h2>
         <div
           className={`inline-block text-bold text-base text-left md:text-lg text-${

--- a/src/components/WidgetTextConcise/WidgetTextConcisePresentation.js
+++ b/src/components/WidgetTextConcise/WidgetTextConcisePresentation.js
@@ -24,13 +24,7 @@ function WidgetTextConcisePresentation({ widgetData }) {
           <span className="leading-loose text-2xl md:text-4xl lg:text-5xl text-center font-bold">
             {title}
           </span>
-          {audio && (
-            <AudioButton
-              audioArray={[audioObject]}
-              iconStyling="fill-current h-9 w-9 sm:w-12 sm:h-12 ml-2"
-              hoverTooltip
-            />
-          )}
+          {audio && <AudioButton audioArray={[audioObject]} hoverTooltip />}
         </div>
         <p className="text-center text-lg md:text-xl lg:text-2xl">{text}</p>
         {url && (

--- a/src/components/WidgetWordOfTheDay/WidgetWordOfTheDayPresentation.js
+++ b/src/components/WidgetWordOfTheDay/WidgetWordOfTheDayPresentation.js
@@ -31,11 +31,7 @@ function WidgetWordOfTheDayPresentation({
             <Link to={relativeUrl}>{wordTitle}</Link>
             {audio && (
               <span className="ml-2 text-black">
-                <AudioButton
-                  audioArray={audio}
-                  iconStyling="fill-current h-9 w-9 sm:w-12 sm:h-12"
-                  hoverTooltip
-                />
+                <AudioButton audioArray={audio} hoverTooltip />
               </span>
             )}
           </div>


### PR DESCRIPTION
### Description of Changes

Converts splashboard buttons on: 

- drawers (song, story, dictionary) 
- main fv search page
- site-wide search page
- dictionary search page
- explore languages page
- categories word list page 
- detail pages (song, story, dictionary)

Additionally reworks how some action item tooltips work, and removes now-unused variables

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] UI review if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
