### PR TITLE
FW-6670 Remove stying from html on paste

### DIFF
--- a/src/common/utils/stringHelpers.js
+++ b/src/common/utils/stringHelpers.js
@@ -1,4 +1,5 @@
-/* eslint-disable max-lines */
+import DOMPurify from 'dompurify'
+
 // FPCC
 import {
   MEMBERS,
@@ -36,6 +37,19 @@ export const extractTextFromHtml = (htmlString) => {
   const span = document.createElement('span')
   span.innerHTML = htmlString
   return span.textContent || span.innerText
+}
+
+export const removeStylingFromHtml = (htmlString) => {
+  // Replace all header tags with paragraph tags
+  const normalizedHtml = htmlString
+    .replace(/<h[1-6]>/gi, '<p>')
+    .replace(/<\/h[1-6]>/gi, '</p>')
+
+  // Remove all style tags except whitespace, line breaks and links
+  return DOMPurify.sanitize(normalizedHtml, {
+    ALLOWED_ATTR: ['href', 'target', 'rel'],
+    ALLOWED_TAGS: ['br', 'p', 'span', 'a'],
+  })
 }
 
 export const getFriendlyType = ({
@@ -268,7 +282,7 @@ export const convertJsonToReadableString = (json) => {
     const message = JSON.stringify(json)
     return message?.replace(/[{}[\]"]+/g, ' ') || ''
   } catch (e) {
-    return 'Error'
+    return `Error converting JSON: ${e.message}`
   }
 }
 

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -37,7 +37,7 @@ function WysiwygField({
     ],
     editorProps: {
       handlePaste: function (view, event) {
-        if (toolbar === 'none' || toolbar.length === 0) {
+        if (toolbar.length === 0) {
           const html = event.clipboardData?.getData('text/html')
           if (!html) return false
 

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -10,6 +10,7 @@ import WysiwygControls from 'components/Form/WysiwygControls'
 import ValidationError from 'components/Form/ValidationError'
 import HelpText from 'components/Form/HelpText'
 import FieldLabel from 'components/Form/FieldLabel'
+import { removeStylingFromHtml } from 'common/utils/stringHelpers'
 
 function WysiwygField({
   label = '',
@@ -34,6 +35,20 @@ function WysiwygField({
         defaultProtocol: 'https:',
       }),
     ],
+    editorProps: {
+      handlePaste: function (view, event) {
+        if (toolbar === 'none' || toolbar.length === 0) {
+          const html = event.clipboardData?.getData('text/html')
+          if (!html) return false
+
+          const strippedHtml = removeStylingFromHtml(html)
+
+          editor.commands.insertContent(strippedHtml)
+          return true // prevents default paste
+        }
+        return false // allow default behavior
+      },
+    },
     content: value,
     onUpdate: ({ editor }) => {
       onChange(editor.getHTML())

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -90,14 +90,16 @@ function WysiwygField({
   )
 }
 // PROPTYPES
-const { array, object, oneOfType, string } = PropTypes
+const { arrayOf, object, oneOf, string } = PropTypes
 WysiwygField.propTypes = {
   helpText: string,
   errors: object,
   label: string,
   nameId: string.isRequired,
   control: object,
-  toolbar: oneOfType([array, string]),
+  toolbar: arrayOf(
+    oneOf(['INLINESTYLES', 'BLOCKSTYLES', 'OL', 'UL', 'HEADER']),
+  ),
 }
 
 export default WysiwygField

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -18,7 +18,7 @@ function WysiwygField({
   errors,
   helpText,
   control,
-  toolbar = ['INLINESTYLES', 'BLOCKSTYLES', 'OL', 'UL', 'HEADER'],
+  toolbar = [],
 }) {
   const {
     field: { onChange, value },

--- a/src/components/Form/WysiwygField.js
+++ b/src/components/Form/WysiwygField.js
@@ -10,7 +10,7 @@ import WysiwygControls from 'components/Form/WysiwygControls'
 import ValidationError from 'components/Form/ValidationError'
 import HelpText from 'components/Form/HelpText'
 import FieldLabel from 'components/Form/FieldLabel'
-import { removeStylingFromHtml } from 'common/utils/stringHelpers'
+import { formatHTMLForTiptap } from 'common/utils/stringHelpers'
 
 function WysiwygField({
   label = '',
@@ -41,7 +41,7 @@ function WysiwygField({
           const html = event.clipboardData?.getData('text/html')
           if (!html) return false
 
-          const strippedHtml = removeStylingFromHtml(html)
+          const strippedHtml = formatHTMLForTiptap(html)
 
           editor.commands.insertContent(strippedHtml)
           return true // prevents default paste

--- a/src/components/SongCrud/SongCrudPresentation.js
+++ b/src/components/SongCrud/SongCrudPresentation.js
@@ -106,7 +106,7 @@ function SongCrudPresentation({
               label="Introduction in your language"
               nameId="intro"
               control={control}
-              toolbar="none"
+              toolbar={[]}
               errors={errors}
             />
           </div>
@@ -115,7 +115,7 @@ function SongCrudPresentation({
               label="Introduction translation"
               nameId="introTranslation"
               control={control}
-              toolbar="none"
+              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/SongCrud/SongCrudPresentation.js
+++ b/src/components/SongCrud/SongCrudPresentation.js
@@ -106,7 +106,6 @@ function SongCrudPresentation({
               label="Introduction in your language"
               nameId="intro"
               control={control}
-              toolbar={[]}
               errors={errors}
             />
           </div>
@@ -115,7 +114,6 @@ function SongCrudPresentation({
               label="Introduction translation"
               nameId="introTranslation"
               control={control}
-              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
+++ b/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
@@ -114,7 +114,6 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
                 label="Introduction in your language"
                 nameId="intro"
                 control={control}
-                toolbar={[]}
                 errors={errors}
               />
             </div>
@@ -123,7 +122,6 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
                 label="Introduction translation"
                 nameId="introTranslation"
                 control={control}
-                toolbar={[]}
                 errors={errors}
               />
             </div>

--- a/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
+++ b/src/components/StoryCoverCrud/StoryCoverCrudPresentation.js
@@ -114,7 +114,7 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
                 label="Introduction in your language"
                 nameId="intro"
                 control={control}
-                toolbar="none"
+                toolbar={[]}
                 errors={errors}
               />
             </div>
@@ -123,7 +123,7 @@ function StoryCoverCrudPresentation({ dataToEdit, submitHandler }) {
                 label="Introduction translation"
                 nameId="introTranslation"
                 control={control}
-                toolbar="none"
+                toolbar={[]}
                 errors={errors}
               />
             </div>

--- a/src/components/StoryPagesCrud/StoryPageForm.js
+++ b/src/components/StoryPagesCrud/StoryPageForm.js
@@ -71,7 +71,7 @@ function StoryPageForm({
             label="Page text"
             nameId="text"
             control={control}
-            toolbar="none"
+            toolbar={[]}
             errors={errors}
           />
         </div>
@@ -80,7 +80,7 @@ function StoryPageForm({
             label="Page translation"
             nameId="textTranslation"
             control={control}
-            toolbar="none"
+            toolbar={[]}
             errors={errors}
           />
         </div>

--- a/src/components/StoryPagesCrud/StoryPageForm.js
+++ b/src/components/StoryPagesCrud/StoryPageForm.js
@@ -71,7 +71,6 @@ function StoryPageForm({
             label="Page text"
             nameId="text"
             control={control}
-            toolbar={[]}
             errors={errors}
           />
         </div>
@@ -80,7 +79,6 @@ function StoryPageForm({
             label="Page translation"
             nameId="textTranslation"
             control={control}
-            toolbar={[]}
             errors={errors}
           />
         </div>

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -85,7 +85,6 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
               label="Address"
               nameId="textWithFormatting"
               control={control}
-              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -85,7 +85,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
               label="Address"
               nameId="textWithFormatting"
               control={control}
-              toolbar="none"
+              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/WidgetCrud/WidgetFormText.js
+++ b/src/components/WidgetCrud/WidgetFormText.js
@@ -85,7 +85,6 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
               label="Text"
               nameId="textWithFormatting"
               control={control}
-              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/WidgetCrud/WidgetFormText.js
+++ b/src/components/WidgetCrud/WidgetFormText.js
@@ -85,7 +85,7 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
               label="Text"
               nameId="textWithFormatting"
               control={control}
-              toolbar="none"
+              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/WidgetCrud/WidgetFormTextFull.js
+++ b/src/components/WidgetCrud/WidgetFormTextFull.js
@@ -10,6 +10,8 @@ import { definitions } from 'common/utils/validationHelpers'
 import WidgetFormBase from 'components/WidgetCrud/WidgetFormBase'
 
 function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
+  const toolbar = ['INLINESTYLES', 'BLOCKSTYLES', 'OL', 'UL', 'HEADER']
+
   const validator = yup.object().shape({
     nickname: definitions.nickname(),
     type: yup.string().required().oneOf([WIDGET_TEXTFULL]),
@@ -60,6 +62,7 @@ function WidgetFormText({ cancelHandler, dataToEdit, submitHandler }) {
             nameId="textWithFormatting"
             control={control}
             errors={errors}
+            toolbar={toolbar}
           />
         </div>
       </WidgetFormBase>

--- a/src/components/WidgetCrud/WidgetFormTextIcons.js
+++ b/src/components/WidgetCrud/WidgetFormTextIcons.js
@@ -72,7 +72,7 @@ function WidgetFormTextIcons({ cancelHandler, dataToEdit, submitHandler }) {
               label="Text"
               nameId="textWithFormatting"
               control={control}
-              toolbar="none"
+              toolbar={[]}
               errors={errors}
             />
           </div>

--- a/src/components/WidgetCrud/WidgetFormTextIcons.js
+++ b/src/components/WidgetCrud/WidgetFormTextIcons.js
@@ -72,7 +72,6 @@ function WidgetFormTextIcons({ cancelHandler, dataToEdit, submitHandler }) {
               label="Text"
               nameId="textWithFormatting"
               control={control}
-              toolbar={[]}
               errors={errors}
             />
           </div>


### PR DESCRIPTION
### Description of Changes
- Adds functions to remove styling from HTML and format HTML properly for TipTap after removing styling
- Adds custom paste behaviour to tiptap to strip styling from pasted HTML if the toolbar does not support styling
- Inverts toolbar usage to specify when there is a toolbar rather when there is not one

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] ~~UI review if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
