### PR TITLE
FW-6197 Open local links in the same tab

### DIFF
--- a/src/components/SanitizedHtml/SanitizedHtml.js
+++ b/src/components/SanitizedHtml/SanitizedHtml.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import DOMPurify from 'dompurify'
 
+const LOCAL_DOMAINS = ['firstvoices.com']
+
 DOMPurify.addHook('uponSanitizeElement', (node, data) => {
   if (data.tagName === 'iframe') {
     const src = node.getAttribute('src') || ''
@@ -11,8 +13,16 @@ DOMPurify.addHook('uponSanitizeElement', (node, data) => {
   }
 
   if (data.tagName === 'a') {
-    node.setAttribute('target', '_blank')
-    node.setAttribute('rel', 'noopener noreferrer')
+    const href = node.getAttribute('href') || ''
+
+    const isLocal = LOCAL_DOMAINS.some((domain) => href.includes(domain))
+    if (!isLocal) {
+      node.setAttribute('target', '_blank')
+      node.setAttribute('rel', 'noopener noreferrer')
+    } else {
+      node.setAttribute('target', '_self')
+      node.removeAttribute('rel')
+    }
   }
 })
 


### PR DESCRIPTION
### Description of Changes
- Opens links to firstvoices.com in the same tab when displayed on a wysiwyg field.
- Only uses same tab when displayed, not on edit pages

### Checklist

- [ ] README / documentation has been updated if needed
- [ ] PR title / commit messages contain Jira ticket number if applicable
- [ ] ~~Tests have been updated / created if applicable~~
- [ ] ~~UI review if applicable~~

### Reviewers Should Do The Following:

- [ ] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
