### PR TITLE
FW-64-91 return 404 page on unknown category

### DIFF
--- a/src/components/ByCategory/ByCategoryContainer.js
+++ b/src/components/ByCategory/ByCategoryContainer.js
@@ -10,6 +10,7 @@ import SiteDocHead from 'components/SiteDocHead'
 function ByCategoryContainer({ kids = null }) {
   const {
     categoriesQueryResponse,
+    categoryQueryResponse,
     currentCategory,
     currentParentCategory,
     searchType,
@@ -21,7 +22,7 @@ function ByCategoryContainer({ kids = null }) {
     tabs,
   } = ByCategoryData({ kids })
   return (
-    <LoadOrError queryResponse={categoriesQueryResponse}>
+    <LoadOrError queryResponse={categoryQueryResponse}>
       <SiteDocHead titleArray={[currentCategory?.title, 'Category']} />
       {kids ? (
         <ByCategoryKids

--- a/src/components/ByCategory/ByCategoryData.js
+++ b/src/components/ByCategory/ByCategoryData.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 // FPCC
 import useSearchType from 'common/hooks/useSearchType'
 import useSearchLoader from 'common/dataHooks/useSearchLoader'
-import { useCategories } from 'common/dataHooks/useCategories'
+import { useCategories, useCategory } from 'common/dataHooks/useCategories'
 import { CATEGORY, KIDS, TYPES, TYPE_DICTIONARY } from 'common/constants'
 import { getPresentationPropertiesForType } from 'common/utils/stringHelpers'
 function ByCategoryData({ kids = null }) {
@@ -29,6 +29,7 @@ function ByCategoryData({ kids = null }) {
   })
 
   const categoriesQueryResponse = useCategories()
+  const categoryQueryResponse = useCategory({ id: categoryId })
 
   const [currentCategory, setCurrentCategory] = useState({})
   const [currentParentCategory, setCurrentParentCategory] = useState({})
@@ -54,6 +55,7 @@ function ByCategoryData({ kids = null }) {
 
   return {
     categoriesQueryResponse,
+    categoryQueryResponse,
     searchInfiniteQueryResponse,
     sitename,
     currentCategory,


### PR DESCRIPTION
### Description of Changes

- Passes a`useCategory` query on the current ID to `ByCategoryContainer`
- LoadOrError ByCategory page based on useCategory rather than useCategories, such that id the selected id is not a category, return a 404 page

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] ~~UI review if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
