### PR TITLE
added a fix for video select and deselect

### DIFF
--- a/src/common/hooks/useArrayStateManager.js
+++ b/src/common/hooks/useArrayStateManager.js
@@ -16,18 +16,21 @@ function useArrayStateManager({ maxItems }) {
     array.some((elem) => elem === item || elem?.id === item?.id)
 
   const handleSelectAdditionalItem = (selectedItem) => {
-    if (maxItems === 1) {
-      setSelectedItems([selectedItem])
-      return
-    }
-    if (maxItems && selectedItems.length >= maxItems) {
-      return
-    }
     const hasItem = checkForItem(selectedItems, selectedItem)
     if (hasItem) {
       setSelectedItems(removeItemFromArray(selectedItems, selectedItem))
       return
     }
+
+    if (maxItems === 1) {
+      setSelectedItems([selectedItem])
+      return
+    }
+
+    if (maxItems && selectedItems.length >= maxItems) {
+      return
+    }
+
     setSelectedItems([...selectedItems, selectedItem])
   }
 

--- a/src/components/AddVideoModal/AddVideoModalContainer.js
+++ b/src/components/AddVideoModal/AddVideoModalContainer.js
@@ -18,21 +18,8 @@ function AddVideoModalContainer({
   modalOpen,
   closeModal,
 }) {
-  const {
-    selectedItems,
-    setSelectedItems,
-    handleSelectAdditionalItem,
-    handleRemoveItem,
-  } = useArrayStateManager({ maxItems })
-
-  const toggleVideoSelection = (video) => {
-    const isSelected = selectedItems.some((v) => v.id === video.id)
-    if (isSelected) {
-      handleRemoveItem(video)
-    } else {
-      handleSelectAdditionalItem(video)
-    }
-  }
+  const { selectedItems, setSelectedItems, handleSelectAdditionalItem } =
+    useArrayStateManager({ maxItems })
 
   // Clear the Selected items when the modal closes
   useEffect(() => {
@@ -93,7 +80,7 @@ function AddVideoModalContainer({
           <SelectorVideos.Container
             formMedia={formMedia}
             selectedMedia={selectedItems}
-            mediaSelectHandler={toggleVideoSelection}
+            mediaSelectHandler={handleSelectAdditionalItem}
           />
         )}
         {currentTab.id === 'video-link-tab' && (

--- a/src/components/AddVideoModal/AddVideoModalContainer.js
+++ b/src/components/AddVideoModal/AddVideoModalContainer.js
@@ -18,8 +18,21 @@ function AddVideoModalContainer({
   modalOpen,
   closeModal,
 }) {
-  const { selectedItems, setSelectedItems, handleSelectAdditionalItem } =
-    useArrayStateManager({ maxItems })
+  const {
+    selectedItems,
+    setSelectedItems,
+    handleSelectAdditionalItem,
+    handleRemoveItem,
+  } = useArrayStateManager({ maxItems })
+
+  const toggleVideoSelection = (video) => {
+    const isSelected = selectedItems.some((v) => v.id === video.id)
+    if (isSelected) {
+      handleRemoveItem(video)
+    } else {
+      handleSelectAdditionalItem(video)
+    }
+  }
 
   // Clear the Selected items when the modal closes
   useEffect(() => {
@@ -80,7 +93,7 @@ function AddVideoModalContainer({
           <SelectorVideos.Container
             formMedia={formMedia}
             selectedMedia={selectedItems}
-            mediaSelectHandler={handleSelectAdditionalItem}
+            mediaSelectHandler={toggleVideoSelection}
           />
         )}
         {currentTab.id === 'video-link-tab' && (


### PR DESCRIPTION
### Description of Changes

video library didn't deselect the video when you clicked and it wasn't possible to remove it at all unless you uploaded or closed the library after clicking.

**update allows selecting and deselecting**

### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] UI review if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
