### PR TITLE
FW-5918 - New version of the Blank Notes Ack Problem

### DIFF
--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -99,14 +99,21 @@ export const definitions = {
   paragraph: ({ charCount = 250 } = {}) => stringWithMax(charCount).nullable(),
 
   textArray: ({ charCount = 225 } = {}) =>
-    yup.array().of(
-      yup.object({
-        text: stringWithMax(charCount).min(
-          1,
-          'This field cannot be empty. Remove it if you do not want to include it.',
-        ),
-      }),
-    ),
+    yup
+      .array()
+      .of(
+        yup.object({
+          text: stringWithMax(charCount).min(
+            1,
+            'This field cannot be empty. Remove it if you do not want to include it.',
+          ),
+        }),
+      )
+      .compact((item) => {
+        const tx = item?.text
+        return typeof tx !== 'string' || tx.trim() === ''
+      })
+      .default([]),
   url: ({ required = false } = {}) =>
     required
       ? yup

--- a/src/components/DictionaryCrud/DictionaryCrudPresentation.js
+++ b/src/components/DictionaryCrud/DictionaryCrudPresentation.js
@@ -29,14 +29,10 @@ function DictionaryCrudPresentation({
   const activeStepNumber = Number(activeStep)
 
   const validator = yup.object().shape({
-    acknowledgements: definitions
-      .textArray({ charCount: 500 })
-      .compact((item) => typeof item !== 'string' || item.trim() === ''),
+    acknowledgements: definitions.textArray({ charCount: 500 }),
     alternateSpellings: definitions.textArray(),
     categories: definitions.objectArray(),
-    notes: definitions
-      .textArray({ charCount: 500 })
-      .compact((item) => typeof item !== 'string' || item.trim() === ''),
+    notes: definitions.textArray({ charCount: 500 }),
     partOfSpeech: definitions.uuid(),
     pronunciations: definitions.textArray(),
     relatedAudio: definitions.idArray(),


### PR DESCRIPTION
### Description of Changes

Saves blank notes & more importantly saved notes with content too. (unlike my last fix)
`.compact(item ⇒ item.text.trim()==='' )` etc etc drops blank entries before validating







### Checklist

- [ ] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] UI review if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
