### PR TITLE
Remove QR code padding and make background transparent

### DIFF
--- a/src/components/Actions/QrcodeCanvas.js
+++ b/src/components/Actions/QrcodeCanvas.js
@@ -9,7 +9,15 @@ function QrcodeCanvas({ url }) {
 
   useEffect(() => {
     const canvas = qrCodeRef.current
-    if (canvas) QRCode.toCanvas(canvas, url)
+    if (canvas) {
+      QRCode.toCanvas(canvas, url, {
+        margin: 0, // Remove padding
+        color: {
+          dark: '#000000', // Keep dots black
+          light: '#FFFFFF00', // Make background transparent
+        },
+      })
+    }
   }, [url])
 
   return <canvas data-testid="QRCode" ref={qrCodeRef} />


### PR DESCRIPTION
Updated QR code generation to include margin and color options.

### Description of Changes

The current QR codes have a white background and significant padding, making them unsuitable for using directly on coloured backgrounds like posters. This change removes the padding and makes the background transparent so they can be used as-is.