### PR TITLE
FW-3716 Separate contact widget urls field

### DIFF
--- a/src/common/utils/validationHelpers.js
+++ b/src/common/utils/validationHelpers.js
@@ -122,10 +122,7 @@ export const definitions = {
       .array()
       .of(
         yup.object({
-          text: stringWithMax(charCount).min(
-            1,
-            'This field cannot be empty. Remove it if you do not want to include it.',
-          ),
+          text: stringWithMax(charCount),
         }),
       )
       .compact((item) => {
@@ -137,10 +134,10 @@ export const definitions = {
     required
       ? yup
           .string()
-          .url('URL must be valid')
+          .url('Must be a valid URL')
           .trim()
           .required('At least one URL is required')
-      : yup.string().url('URL must be valid').trim(),
+      : yup.string().url('Must be a valid URL').trim(),
   uuid: () => uuid,
   nickname: ({ charCount = 45 } = {}) =>
     yup
@@ -212,4 +209,17 @@ export const definitions = {
           ],
         ]),
     ),
+  urlsArray: () =>
+    yup
+      .array()
+      .of(
+        yup.object({
+          text: yup.string().url('Must be a valid URL').trim(),
+        }),
+      )
+      .compact((item) => {
+        const tx = item?.text
+        return typeof tx !== 'string' || tx.trim() === ''
+      })
+      .default([]),
 }

--- a/src/components/WidgetCrud/WidgetCrudPresentation.js
+++ b/src/components/WidgetCrud/WidgetCrudPresentation.js
@@ -156,14 +156,26 @@ function WidgetForm({ cancelHandler, dataToEdit, submitHandler, type }) {
         />
       )
 
-    case WIDGET_CONTACT:
+    case WIDGET_CONTACT: {
+      // Separate urls string into separate objects with text property for form
+      const splitUrls = dataToEdit?.urls ? dataToEdit?.urls?.split(',') : []
+      const _dataToEdit = {
+        ...dataToEdit,
+        urls: splitUrls?.map((url) => ({ text: url })),
+      }
+      // Join urls into a single string for the api
+      const _submitHandler = (formData) => {
+        const urlStrings = formData?.urls?.map((url) => url?.text)
+        submitHandler({ ...formData, urls: urlStrings?.join(',') })
+      }
       return (
         <WidgetFormContact
           cancelHandler={cancelHandler}
-          dataToEdit={dataToEdit}
-          submitHandler={submitHandler}
+          dataToEdit={_dataToEdit}
+          submitHandler={_submitHandler}
         />
       )
+    }
 
     case WIDGET_GALLERY:
       return (

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -18,7 +18,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
     title: definitions.title().required('A title is required'),
     text: definitions.paragraph(),
     textWithFormatting: definitions.wysiwyg({ charCount: 200 }),
-    urls: yup.string().max(500).trim(),
+    urls: definitions.textArray(),
     visibility: definitions.visibility(),
   })
 
@@ -30,7 +30,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
     title: 'CONTACT US',
     text: 'Please contact us if you have any suggestions or feedback regarding our language content.',
     textWithFormatting: '',
-    urls: '',
+    urls: [],
   }
 
   const {
@@ -89,12 +89,13 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
             />
           </div>
           <div className="col-span-12">
-            <Form.TextField
+            <Form.TextArrayField
               label="Social media links"
               nameId="urls"
-              helpText="Enter any URLs you would like to include separated by commas."
               register={register}
+              control={control}
               errors={errors}
+              maxItems={5}
             />
           </div>
           {data?.emailListAsString?.length > 0 ? (

--- a/src/components/WidgetCrud/WidgetFormContact.js
+++ b/src/components/WidgetCrud/WidgetFormContact.js
@@ -18,7 +18,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
     title: definitions.title().required('A title is required'),
     text: definitions.paragraph(),
     textWithFormatting: definitions.wysiwyg({ charCount: 200 }),
-    urls: definitions.textArray(),
+    urls: definitions.urlsArray(),
     visibility: definitions.visibility(),
   })
 
@@ -92,6 +92,7 @@ function WidgetFormContact({ cancelHandler, dataToEdit, submitHandler }) {
             <Form.TextArrayField
               label="Social media links"
               nameId="urls"
+              helpText="Enter a maximum of 5 links."
               register={register}
               control={control}
               errors={errors}


### PR DESCRIPTION
### Description of Changes

Separates urls string in Contact Us Widget form into individual fields for easier editing.

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [ ] Tests have been updated / created if applicable
- [ ] UI review if applicable

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

N/A
