### PR TITLE
FW-7039 Ensure tif files are displayed on media edit

### DIFF
--- a/src/common/dataAdaptors/mediaAdaptors.js
+++ b/src/common/dataAdaptors/mediaAdaptors.js
@@ -39,6 +39,12 @@ const baseMediaAdaptor = ({ data }) => {
   return formattedData
 }
 
+const thumbnailAdaptor = ({ data }) => ({
+  thumbnail: data?.thumbnail || {},
+  small: data?.small || {},
+  medium: data?.medium || {},
+})
+
 export const audioForEditing = ({ data }) => {
   const formattedData = {
     ...baseMediaAdaptor({ data }),
@@ -65,6 +71,7 @@ export const imageForEditing = ({ data }) => {
   const formattedData = {
     ...baseMediaAdaptor({ data }),
     ...audienceForEditing({ item: data }),
+    ...thumbnailAdaptor({ data }),
   }
   return formattedData
 }

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -24,13 +24,15 @@ import {
 } from 'common/constants'
 // NB ALL sizes supplied for VIDEO or images of mime-type 'gif' will return a static image src except for ORIGINAL
 export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
-  const path = mediaObject?.original?.path
   if (!mediaObject?.original) {
     return `${type} object with the property of 'original' must be supplied to retrieve a src path.`
   }
   if (![ORIGINAL, SMALL, MEDIUM, THUMBNAIL].includes(size)) {
     return 'Only ORIGINAL, SMALL, MEDIUM, or THUMBNAIL are accepted as sizes for media.'
   }
+
+  const path = mediaObject?.original?.path
+
   switch (type) {
     case AUDIO:
     case DOCUMENT:

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -32,6 +32,7 @@ export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
   }
 
   const path = mediaObject?.original?.path
+  const isTiffFile = path?.toLowerCase().match(/\.tiff?$/)
 
   switch (type) {
     case AUDIO:
@@ -40,10 +41,7 @@ export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
     case VIDEO:
       return mediaObject?.[size]?.path
     case IMAGE:
-      if (
-        (path.endsWith('.tif') || path.endsWith('.tiff')) &&
-        size === ORIGINAL
-      ) {
+      if (isTiffFile && size === ORIGINAL) {
         return mediaObject?.[MEDIUM]?.path
       }
       return mediaObject?.[size]?.path || mediaObject?.original?.path

--- a/src/common/utils/mediaHelpers.js
+++ b/src/common/utils/mediaHelpers.js
@@ -24,6 +24,7 @@ import {
 } from 'common/constants'
 // NB ALL sizes supplied for VIDEO or images of mime-type 'gif' will return a static image src except for ORIGINAL
 export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
+  const path = mediaObject?.original?.path
   if (!mediaObject?.original) {
     return `${type} object with the property of 'original' must be supplied to retrieve a src path.`
   }
@@ -37,6 +38,12 @@ export const getMediaPath = ({ mediaObject, type, size = ORIGINAL }) => {
     case VIDEO:
       return mediaObject?.[size]?.path
     case IMAGE:
+      if (
+        (path.endsWith('.tif') || path.endsWith('.tiff')) &&
+        size === ORIGINAL
+      ) {
+        return mediaObject?.[MEDIUM]?.path
+      }
       return mediaObject?.[size]?.path || mediaObject?.original?.path
 
     default:

--- a/src/components/Form/ImageArrayField.js
+++ b/src/components/Form/ImageArrayField.js
@@ -36,16 +36,18 @@ function ImageArrayField({
         <ul>
           {fields?.length > 0 &&
             fields?.map((image, index) => (
-              <li
-                key={image?.key}
-                className="inline-flex border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1 mr-2 mb-2"
-              >
-                <MediaThumbnail.Image
-                  imageObject={image}
-                  imageStyles="object-cover pointer-events-none"
-                />
-
-                <XButton onClickHandler={() => remove(index)} />
+              <li key={image?.key} className="inline-block align-top mr-2 mb-2">
+                <div className="flex items-start border border-transparent bg-white rounded-lg shadow-md text-sm font-medium p-2 pr-0 space-x-1">
+                  <div className="shrink-0">
+                    <MediaThumbnail.Image
+                      imageObject={image}
+                      imageStyles="w-full aspect-3/2 object-cover pointer-events-none"
+                    />
+                  </div>
+                  <div className="shrink-0">
+                    <XButton onClickHandler={() => remove(index)} />
+                  </div>
+                </div>
               </li>
             ))}
         </ul>

--- a/src/components/ImageCrud/ImageCrudData.js
+++ b/src/components/ImageCrud/ImageCrudData.js
@@ -10,7 +10,7 @@ function ImageCrudData() {
   const { sitename } = useParams()
   const id = searchParams.get('id')
 
-  const queryResponse = useImage({ id })
+  const queryResponse = useImage({ id, edit: true })
 
   const { onSubmit } = useImageUpdate({ id })
   const submitHandler = (formData) => onSubmit(formData)

--- a/src/components/ImageCrud/ImageCrudData.js
+++ b/src/components/ImageCrud/ImageCrudData.js
@@ -10,7 +10,7 @@ function ImageCrudData() {
   const { sitename } = useParams()
   const id = searchParams.get('id')
 
-  const queryResponse = useImage({ id, edit: true })
+  const queryResponse = useImage({ id })
 
   const { onSubmit } = useImageUpdate({ id })
   const submitHandler = (formData) => onSubmit(formData)

--- a/src/components/MediaThumbnail/ImageThumbnail.js
+++ b/src/components/MediaThumbnail/ImageThumbnail.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 // FPCC
 import { useImage } from 'common/dataHooks/useImages'
+import getIcon from 'common/utils/getIcon'
 import { getMediaPath } from 'common/utils/mediaHelpers'
 import { TYPE_IMAGE, SMALL } from 'common/constants'
 
@@ -31,15 +32,31 @@ function ImageThumbnail({
     }
   }, [src, setSrc, fetchedImageObject, imageObject])
 
+  const isTiffFile = src?.toLowerCase().match(/\.tiff?$/)
+
   return (
     <div id="MediaThumbnailImage" className={containerStyles}>
-      <img
-        src={src}
-        alt={imageObject?.title || fetchedImageObject?.title}
-        className={imageStyles}
-        loading="lazy"
-        {...other}
-      />
+      {isTiffFile ? (
+        <div className="w-full h-full flex flex-col items-center justify-center text-center p-2 space-y-1">
+          {getIcon('Images', 'w-8 h-8 text-charcoal-600 fill-current')}
+          <span className="text-xs text-charcoal-600 font-medium">
+            Thumbnail will appear on save.
+          </span>
+          {(imageObject?.title || fetchedImageObject?.title) && (
+            <span className="text-xs text-charcoal-600 line-clamp-2">
+              {imageObject?.title || fetchedImageObject?.title}
+            </span>
+          )}
+        </div>
+      ) : (
+        <img
+          src={src}
+          alt={imageObject?.title || fetchedImageObject?.title}
+          className={imageStyles}
+          loading="lazy"
+          {...other}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
### Description of Changes

- Adds a case to `getMediaPath` where if a tif file is required to be displayed, display the medium jpg rather than the original tif file
- Adds a `ThumbnailAdaptor` to display image thumbnail data
- Adds a tiff thumbnail placeholder
- Fixes alignment of thumbnail boxes when both thumbnails and placeholders are present

### Checklist

- [x] README / documentation has been updated if needed
- [x] PR title / commit messages contain Jira ticket number if applicable
- [x] ~~Tests have been updated / created if applicable~~
- [x] ~~UI review if applicable~~

### Reviewers Should Do The Following:

- [x] Review the changes here
- [ ] Pull the branch and test locally

### Additional Notes

Note that the thumbnails for tif files will still be blank, but only on initial upload. After completing the entry creation thumbnails will appear
